### PR TITLE
Add run scripts for running PX4 SITL from this repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,12 +3,27 @@
 
 This repository allows a data-driven dynamics model for PX4 SITL(Software-In-The-Loop) simulations.
 
-## Build
-This plugin depends on [PX4 SITL](https://github.com/PX4/PX4-SITL_gazebo). Therefore custom messages of PX4 SITL needs to be linked.
+## Setting up the environment
+This plugin depends on [PX4 SITL](https://github.com/PX4/PX4-SITL_gazebo). Therefore custom messages of PX4 SITL needs to be linked. Therefore, prior to building this package, PX4 and corresponding SITL package needs to be built.
 
-This can be done by setting the environment variable `PX4_ROOT` to the root of the PX4 Autopilot firmware directory.
+In case you have not cloned the firmware repository
 ```
-export PX4_ROOT=~/src/PX4-Autopilot
+git clone --recursive https://github.com/ethz-asl/ethzasl_fw_px4.git ~/dev/PX4-Autopilot ~/src/PX4-Autopilot
+```
+```
+cd <Firmware Dir>
+DONT_RUN=1 make px4_sitl gazebo
+```
+
+The build directory of PX4 can be linked by setting the environment variable `PX4_ROOT` to the root of the firmware directory. Set the environment variable `export PX4_ROOT=~/src/PX4-Autopilot` or add it to your `bashrc`
+```
+echo "export PX4_ROOT=~/src/PX4-Autopilot" >> ~/.bashrc
+source ~/.bashrc
+```
+
+## Build
+After the environment has been setup as described in the previous section, build the package as the following.
+```
 mkdir build
 cd build
 cmake ..

--- a/Tools/sitl_run.sh
+++ b/Tools/sitl_run.sh
@@ -1,0 +1,75 @@
+#!/bin/bash
+#
+# run multiple instances of the 'px4' binary, with the gazebo SITL simulation
+# It assumes px4 is already built, with 'make px4_sitl_default gazebo'
+
+# The simulator is expected to send to TCP port 4560+i for i in [0, N-1]
+# For example gazebo can be run like this:
+#./Tools/gazebo_sitl_multiple_run.sh -n 10 -m iris
+
+function cleanup() {
+	pkill -x px4
+	pkill gzclient
+	pkill gzserver
+}
+
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+src_path="$SCRIPT_DIR/.."
+
+echo ${SCRIPT}
+source ${src_path}/setup.bash
+
+if [ "$1" == "-h" ] || [ "$1" == "--help" ]
+then
+	echo "Usage: $0 [-m <vehicle_model>] [-w <world>]"
+	exit 1
+fi
+
+while getopts m:w:s: option
+do
+	case "${option}"
+	in
+		m) VEHICLE_MODEL=${OPTARG};;
+		w) WORLD=${OPTARG};;
+		s) SDF_MODEL=${OPTARG};;
+	esac
+done
+
+world=${WORLD:=empty}
+export PX4_SIM_MODEL=${VEHICLE_MODEL:=iris}
+GAZEBO_MODEL=${SDF_MODEL};
+
+build_path=${PX4_ROOT}/build/px4_sitl_default
+mavlink_udp_port=14560
+mavlink_tcp_port=4560
+
+echo "killing running instances"
+pkill -x px4 || true
+
+sleep 1
+
+source ${PX4_ROOT}/Tools/setup_gazebo.bash ${PX4_ROOT} ${PX4_ROOT}/build/px4_sitl_default
+
+echo "Starting gazebo"
+gzserver ${PX4_ROOT}/Tools/sitl_gazebo/worlds/${world}.world --verbose &
+sleep 5
+
+echo "Spawning ${GAZEBO_MODEL}"
+
+gz model --spawn-file=${src_path}/models/${GAZEBO_MODEL}/${GAZEBO_MODEL}.sdf --model-name=${GAZEBO_MODEL} -x 0.0 -y 3.0 -z 0.83
+
+trap "cleanup" SIGINT SIGTERM EXIT
+
+echo "Starting gazebo client"
+gzclient &
+
+# spawn_model ${PX4_SIM_MODEL}
+
+working_dir="$build_path/tmp/rootfs"
+[ ! -d "$working_dir" ] && mkdir -p "$working_dir"
+
+pushd "$working_dir" &>/dev/null
+echo "starting instance $N in $(pwd)"
+../../bin/px4 "$build_path/etc" -w sitl_${MODEL} -s etc/init.d-posix/rcS
+
+popd &>/dev/null

--- a/setup.bash
+++ b/setup.bash
@@ -7,3 +7,5 @@ SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 export GAZEBO_PLUGIN_PATH=$GAZEBO_PLUGIN_PATH:${SCRIPT_DIR}/build
 export GAZEBO_MODEL_PATH=$GAZEBO_MODEL_PATH:${SCRIPT_DIR}/models
+
+export PX4_ROOT=~/src/PX4-Autopilot


### PR DESCRIPTION
**Problem Description**
Add run scripts to run PX4 SITL from this repository. SITL can be run using the following script
```
Tools/sitl_run.sh -m techpod -s techpod_aerodynamics
```
where `-m` specifies which model (airframe config) to run and `-s` specifies the gazebo model (sdf model) to run SITL with.

Detailed instructions are included in the readme