### PR TITLE
Add yaml-cpp dependency for build checks in github actions

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -31,6 +31,7 @@ jobs:
         cd build
         cmake ..
         make
+        make install
     - name: Install latest mavlink
       run: git clone --depth 1 https://github.com/mavlink/c_library_v2.git /usr/local/include/mavlink/v2.0 && rm -rf /usr/local/include/mavlink/v2.0/.git
     - name: Clone PX4


### PR DESCRIPTION
**Problem Description**
There was a new dependency([yaml-cpp](https://github.com/jbeder/yaml-cpp)) added in https://github.com/Jaeyoung-Lim/data-driven-dynamics/pull/2

This PR installs `yaml-cpp` in the github actions build test so that the build tests don't fail