### PR TITLE
Create a symbolic link to the logging directory of PX4

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 build/*
+logs*

--- a/setup.bash
+++ b/setup.bash
@@ -13,3 +13,6 @@ export PX4_ROOT=~/src/PX4-Autopilot
 
 export GAZEBO_PLUGIN_PATH=$GAZEBO_PLUGIN_PATH:${PX4_ROOT}/build/px4_sitl_gazebo_default/build_gazebo
 export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:${PX4_ROOT}/build/px4_sitl_gazebo_default/build_gazebo
+
+# Create symbolic link of logging directory if doesn't exist
+ln -snf ${PX4_ROOT}/build/px4_sitl_default/logs $SCRIPT_DIR/logs


### PR DESCRIPTION
**Problem Description**
This commit makes the setup script to create a symbolic link to the logging directory of PX4, so that the logs appear whenever a new log appears

This saves a step where the logs need to be manually copied.

@manumerous FYI