### PR TITLE
Fix log directory path to PX4

### DIFF
--- a/Tools/sitl_run.sh
+++ b/Tools/sitl_run.sh
@@ -70,6 +70,6 @@ working_dir="$build_path/tmp/rootfs"
 
 pushd "$working_dir" &>/dev/null
 echo "starting instance $N in $(pwd)"
-../../bin/px4 "$build_path/etc" -w sitl_${MODEL} -s etc/init.d-posix/rcS
+../../bin/px4 "$build_path/etc" -s etc/init.d-posix/rcS
 
 popd &>/dev/null


### PR DESCRIPTION
**Problem Description**
When running the `Tools/sitl_run.sh` the log symbolic link was pointing to the wrong path. This PR fixes this problem by removing the `-w` flag when running the px4 binary

**Testing**
Tested by running the following command
```
Tools/sitl_run.sh
```

**Additional Context**
- This PR fixes https://github.com/Jaeyoung-Lim/data-driven-dynamics/issues/11