### PR TITLE
Add build environment with docker

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,14 @@
+version?=latest
+registry?=ethzasl/data-driven-dynamics
+
+docker-build:
+	docker build -f docker/Dockerfile --tag ${registry}:${version} .
+
+docker-push:
+	docker push ${registry}:${version}
+
+docker-publish: docker-build docker-push
+
+docker-run:
+	xhost local:root
+	docker run -it --rm -e DISPLAY -v /tmp/.X11-unix:/tmp/.X11-unix ${registry}:${version} /bin/bash

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,5 @@
+FROM px4io/px4-dev-simulation-focal:2020-08-14 as build-env
+
+# RUN mkdir -p /root/data-driven-dynamics
+COPY . /root/data-driven-dynamics
+WORKDIR /root/data-driven-dynamics


### PR DESCRIPTION
**Problem Description**
As discussed in the weekly, this is the docker environment that you can use @manumerous 
xhost is also linked to the container, therefore running gui programs in the container is possible. 

To build the environment
```
make docker-build
```

To start the container
```
make docker-run
```
e.g. when running the following command in the container
```
gazebo
```
![image](https://user-images.githubusercontent.com/5248102/111917065-469ae200-8a7e-11eb-8b4f-afbd37372ba8.png)
