### PR TITLE
Use airspeed sensor models for airspeed sensor

### DIFF
--- a/models/standard_vtol_aerodynamics/standard_vtol_aerodynamics.sdf
+++ b/models/standard_vtol_aerodynamics/standard_vtol_aerodynamics.sdf
@@ -920,10 +920,15 @@
       <pubRate>50</pubRate>
       <baroTopic>/baro</baroTopic>
     </plugin>
-    <plugin name='airspeed_plugin' filename='libgazebo_airspeed_plugin.so'>
-      <robotNamespace/>
-      <linkName>standard_vtol/airspeed_link</linkName>
-    </plugin>
+    <include>
+      <uri>model://airspeed</uri>
+      <pose>0 0 0 0 0 0</pose>
+      <name>airspeed</name>
+    </include>
+    <joint name='airspeed_joint' type='fixed'>
+      <child>airspeed::link</child>
+      <parent>base_link</parent>
+    </joint>
     <plugin name='mavlink_interface' filename='libgazebo_mavlink_interface.so'>
       <robotNamespace></robotNamespace>
       <imuSubTopic>/imu</imuSubTopic>

--- a/models/techpod_aerodynamics/techpod_aerodynamics.sdf
+++ b/models/techpod_aerodynamics/techpod_aerodynamics.sdf
@@ -497,10 +497,15 @@
       <child>gps::link</child>
       <parent>base_link</parent>
     </joint>
-    <plugin name='aerodynamics' filename='libgazebo_fw_dynamics_plugin.so'>
-      <robotNamespace></robotNamespace>
-      <linkName>base_link</linkName>
-    </plugin>
+    <include>
+      <uri>model://airspeed</uri>
+      <pose>0 0 0 0 0 0</pose>
+      <name>airspeed</name>
+    </include>
+    <joint name='airspeed_joint' type='fixed'>
+      <child>airspeed::link</child>
+      <parent>base_link</parent>
+    </joint>
     <plugin name='puller' filename='libgazebo_motor_model.so'>
       <robotNamespace></robotNamespace>
       <jointName>rotor_puller_joint</jointName>


### PR DESCRIPTION
**Problem Description**
The airspeed plugin in PX4 SITL has been updated to be used as a sensor plugin. (Previously it was a model plugin): https://github.com/PX4/PX4-SITL_gazebo/pull/731

This PR updates the models to use the airspeed models. 

**Additional Context**
- This is needed to make this repo work with the latest PX4 @tstastny 