### PR TITLE
Automate dependency installations

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,9 @@
 version?=latest
 registry?=ethzasl/data-driven-dynamics
 
+install-dependencies:
+	pip3 install -r Tools/parametric_model/requirements.txt
+
 docker-build:
 	docker build -f docker/Dockerfile --tag ${registry}:${version} .
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ The use the parametric model structure you need to install python 3.8 and the ne
 Install the dependencies from the project folder:
 
 ```
-pip3 install -r Tools/parametric_modelrequirements.txt
+make install-dependencies
 ```
 
 ## Build


### PR DESCRIPTION
**Problem Description**
Automate python dependency installations using make

e.g.
```
make install-dependencies
```

**Additional Context**
- This resolves just a bit of annoyance when looking for the requirements.txt file