### PR TITLE
Make parametric dynamics into a library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -64,6 +64,7 @@ include_directories(
 add_library(gazebo_fw_dynamics_plugin
   SHARED 
   src/gazebo_fw_dynamics_plugin.cpp
+  src/parametric_dynamics_model.cpp
   )
 target_link_libraries(gazebo_fw_dynamics_plugin 
   ${GAZEBO_LIBRARIES} 

--- a/include/aero_parameters.h
+++ b/include/aero_parameters.h
@@ -20,6 +20,7 @@
 #include <Eigen/Dense>
 #include <yaml-cpp/yaml.h>
 #include <exception>
+#include <gazebo/gazebo.hh>
 
 namespace gazebo {
 

--- a/include/gazebo_fw_dynamics_plugin.h
+++ b/include/gazebo_fw_dynamics_plugin.h
@@ -31,19 +31,12 @@
 #include "Wind.pb.h"
 
 #include "aero_parameters.h"
+#include "parametric_dynamics_model.h"
+
 namespace gazebo {
 
 typedef const boost::shared_ptr<const physics_msgs::msgs::Wind> WindPtr;
 typedef const boost::shared_ptr<const mav_msgs::msgs::CommandMotorSpeed> CommandMotorSpeedPtr;
-
-
-// Default values.
-static constexpr bool kDefaultIsInputJoystick = false;
-
-// Constants.
-static constexpr double kAirDensity = 1.18;
-static constexpr double kGravity = 9.81;
-static constexpr double kMinAirSpeedThresh = 0.1;
 
 class GazeboFwDynamicsPlugin : public ModelPlugin {
  public:
@@ -117,6 +110,9 @@ class GazeboFwDynamicsPlugin : public ModelPlugin {
 
   /// \brief    The physical properties of the aircraft.
   FWVehicleParameters vehicle_params_;
+
+  /// \brief    The parametric model of the aircraft
+  std::shared_ptr<ParametricDynamicsModel> parametric_model_;
 
   /// \brief    Left aileron deflection [rad].
   double delta_aileron_left_;

--- a/include/parametric_dynamics_model.h
+++ b/include/parametric_dynamics_model.h
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2017 Pavel Vechersky, ASL, ETH Zurich, Switzerland
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef PARAMETRIC_DYNAMICS_MODEL_H
+#define PARAMETRIC_DYNAMICS_MODEL_H
+
+#include "aero_parameters.h"
+
+#include <Eigen/Eigen>
+#include <ignition/math.hh>
+
+// Constants.
+static constexpr double kAirDensity = 1.18;
+static constexpr double kGravity = 9.81;
+static constexpr double kMinAirSpeedThresh = 0.1;
+
+namespace gazebo {
+
+class ParametricDynamicsModel {
+  public:
+    ParametricDynamicsModel();
+    virtual ~ParametricDynamicsModel();
+    void setState(const ignition::math::Vector3d &B_air_speed_W_B, const ignition::math::Vector3d &B_angular_velocity_W_B, 
+          double delta_aileron_left, double delta_aileron_right, double delta_elevator, double delta_flap, double delta_rudder);
+    void LoadAeroParams(std::string aero_params_yaml) {
+      aero_params_->LoadAeroParamsYAML(aero_params_yaml);
+    };
+    void LoadVehicleParams(std::string vehicle_params_yaml) {
+      vehicle_params_->LoadVehicleParamsYAML(vehicle_params_yaml);
+    };
+    Eigen::Vector3d getForce() {return force_;};
+    Eigen::Vector3d getMoment() {return moment_;};
+    std::shared_ptr<FWAerodynamicParameters> getAeroParams(){return aero_params_;};
+    std::shared_ptr<FWVehicleParameters> getVehicleParams(){return vehicle_params_;};
+
+  private:
+    Eigen::Vector3d force_{Eigen::Vector3d::Zero()};
+    Eigen::Vector3d moment_{Eigen::Vector3d::Zero()};
+    /// \brief    Throttle input, in range from 0 to 1.
+    double throttle_{0.0};
+      /// \brief    The aerodynamic properties of the aircraft.
+    std::shared_ptr<FWAerodynamicParameters> aero_params_;
+
+    /// \brief    The physical properties of the aircraft.
+    std::shared_ptr<FWVehicleParameters> vehicle_params_;
+};
+}
+#endif // PARAMETRIC_DYNAMICS_MODEL_H

--- a/models/techpod_aerodynamics/techpod_aerodynamics.sdf
+++ b/models/techpod_aerodynamics/techpod_aerodynamics.sdf
@@ -83,39 +83,6 @@
         <use_parent_model_frame>1</use_parent_model_frame>
       </axis>
     </joint>
-    <link name='techpod/airspeed_link'>
-      <pose>0 0 0 0 0 0</pose>
-      <inertial>
-        <pose>0 0 0 0 0 0</pose>
-        <mass>0.015</mass>
-        <inertia>
-          <ixx>1e-05</ixx>
-          <ixy>0</ixy>
-          <ixz>0</ixz>
-          <iyy>1e-05</iyy>
-          <iyz>0</iyz>
-          <izz>1e-05</izz>
-        </inertia>
-      </inertial>
-    </link>
-    <joint name='techpod/airspeed_joint' type='revolute'>
-      <child>techpod/airspeed_link</child>
-      <parent>base_link</parent>
-      <axis>
-        <xyz>1 0 0</xyz>
-        <limit>
-          <lower>0</lower>
-          <upper>0</upper>
-          <effort>0</effort>
-          <velocity>0</velocity>
-        </limit>
-        <dynamics>
-          <spring_reference>0</spring_reference>
-          <spring_stiffness>0</spring_stiffness>
-        </dynamics>
-        <use_parent_model_frame>1</use_parent_model_frame>
-      </axis>
-    </joint>
     <link name='rotor_puller'>
       <pose>-0.025 0 0.15 0 1.57 0</pose>
       <inertial>
@@ -525,6 +492,10 @@
       <robotNamespace></robotNamespace>
       <windSubTopic>world_wind</windSubTopic>
     </plugin>
+    <plugin name='aerodynamics' filename='libgazebo_fw_dynamics_plugin.so'>
+      <robotNamespace></robotNamespace>
+      <linkName>base_link</linkName>
+    </plugin>
     <plugin name='gazebo_imu_plugin' filename='libgazebo_imu_plugin.so'>
       <robotNamespace></robotNamespace>
       <linkName>techpod/imu_link</linkName>
@@ -553,10 +524,6 @@
       <robotNamespace/>
       <pubRate>50</pubRate>
       <baroTopic>/baro</baroTopic>
-    </plugin>
-    <plugin name='airspeed_plugin' filename='libgazebo_airspeed_plugin.so'>
-      <robotNamespace/>
-      <linkName>techpod/airspeed_link</linkName>
     </plugin>
     <plugin name='mavlink_interface' filename='libgazebo_mavlink_interface.so'>
       <robotNamespace></robotNamespace>

--- a/src/gazebo_fw_dynamics_plugin.cpp
+++ b/src/gazebo_fw_dynamics_plugin.cpp
@@ -38,15 +38,11 @@ GazeboFwDynamicsPlugin::~GazeboFwDynamicsPlugin() {
 void GazeboFwDynamicsPlugin::Load(physics::ModelPtr _model,
                                   sdf::ElementPtr _sdf) {
 
-  gzdbg << "_model = " << _model->GetName() << std::endl;
-
   // Store the pointer to the model.
   model_ = _model;
   world_ = model_->GetWorld();
 
   namespace_.clear();
-
-  gzdbg << "dbg1" << std::endl;
 
   // Get the robot namespace.
   if (_sdf->HasElement("robotNamespace"))
@@ -59,8 +55,6 @@ void GazeboFwDynamicsPlugin::Load(physics::ModelPtr _model,
 
   // Initialise with default namespace (typically /gazebo/default/).
   node_handle_->Init();
-
-  gzdbg << "dbg2" << std::endl;
 
   // Get the link name.
   std::string link_name;
@@ -75,16 +69,15 @@ void GazeboFwDynamicsPlugin::Load(physics::ModelPtr _model,
             << link_name << "\".");
   }
 
-  gzdbg << "dbg3" << std::endl;
-
+  parametric_model_ = std::make_shared<ParametricDynamicsModel>();
   // Get the path to fixed-wing aerodynamics parameters YAML file. If not
   // provided, default Techpod parameters are used.
   if (_sdf->HasElement("aeroParamsYAML")) {
-    gzdbg << "dbg3.0" << std::endl;
     std::string aero_params_yaml =
         _sdf->GetElement("aeroParamsYAML")->Get<std::string>();
 
     aero_params_.LoadAeroParamsYAML(aero_params_yaml);
+    parametric_model_->LoadAeroParams(aero_params_yaml);
   } else {
     gzwarn << "[gazebo_fw_dynamics_plugin] No aerodynamic paramaters YAML file"
         << " specified, using default Techpod parameters.\n";
@@ -97,6 +90,7 @@ void GazeboFwDynamicsPlugin::Load(physics::ModelPtr _model,
         _sdf->GetElement("vehicleParamsYAML")->Get<std::string>();
 
     vehicle_params_.LoadVehicleParamsYAML(vehicle_params_yaml);
+    parametric_model_->LoadVehicleParams(vehicle_params_yaml);
   } else {
     gzwarn << "[gazebo_fw_dynamics_plugin] No vehicle paramaters YAML file"
         << " specified, using default Techpod parameters.\n";
@@ -137,132 +131,18 @@ void GazeboFwDynamicsPlugin::UpdateForcesAndMoments(Eigen::Vector3d &forces, Eig
       link_->WorldLinearVel() - W_wind_speed_W_B_);
   ignition::math::Vector3d B_angular_velocity_W_B = link_->RelativeAngularVel();
 
-  // Traditionally, fixed-wing aerodynamics use NED (North-East-Down) frame,
-  // but since our model's body frame is in North-West-Up frame we rotate the
-  // linear and angular velocities by 180 degrees around the X axis.
-  double u = B_air_speed_W_B.X();
-  double v = -B_air_speed_W_B.Y();
-  double w = -B_air_speed_W_B.Z();
+  parametric_model_->setState(B_air_speed_W_B, B_angular_velocity_W_B, delta_aileron_left_, 
+    delta_aileron_right_, delta_elevator_, delta_flap_, delta_rudder_);
 
-  double p = B_angular_velocity_W_B.X();
-  double q = -B_angular_velocity_W_B.Y();
-  double r = -B_angular_velocity_W_B.Z();
+  const Eigen::Vector3d parametric_force = parametric_model_->getForce();
+  const Eigen::Vector3d parametric_moment = parametric_model_->getMoment();
 
-  // Compute the angle of attack (alpha) and the sideslip angle (beta). To
-  // avoid division by zero, there is a minimum air speed threshold below which
-  // alpha and beta are zero.
-  double V = B_air_speed_W_B.Length();
-  double beta = (V < kMinAirSpeedThresh) ? 0.0 : asin(v / V);
-  double alpha = (u < kMinAirSpeedThresh) ? 0.0 : atan(w / u);
+  //TODO: Implement Residual dynamics prediction
+  const Eigen::Vector3d residual_force{Eigen::Vector3d::Zero()};
+  const Eigen::Vector3d residual_moment{Eigen::Vector3d::Zero()};
 
-  // Bound the angle of attack.
-  if (alpha > aero_params_.alpha_max)
-    alpha = aero_params_.alpha_max;
-  else if (alpha < aero_params_.alpha_min)
-    alpha = aero_params_.alpha_min;
-
-  // Pre-compute the common component in the force and moment calculations.
-  const double q_bar_S = 0.5 * kAirDensity * V * V * vehicle_params_.wing_surface;
-
-  // Combine some of the control surface deflections.
-  double aileron_sum = delta_aileron_left_ + delta_aileron_right_;
-  double aileron_diff = delta_aileron_left_ - delta_aileron_right_;
-  double flap_sum = 2.0 * delta_flap_;
-  double flap_diff = 0.0;
-
-  // Compute the forces in the wind frame.
-  const double drag = q_bar_S *
-      (aero_params_.c_drag_alpha.dot(
-           Eigen::Vector3d(1.0, alpha, alpha * alpha)) +
-       aero_params_.c_drag_beta.dot(
-           Eigen::Vector3d(0.0, beta, beta * beta)) +
-       aero_params_.c_drag_delta_ail.dot(
-           Eigen::Vector3d(0.0, aileron_sum, aileron_sum * aileron_sum)) +
-       aero_params_.c_drag_delta_flp.dot(
-           Eigen::Vector3d(0.0, flap_sum, flap_sum * flap_sum)));
-
-  const double side_force = q_bar_S *
-      (aero_params_.c_side_force_beta.dot(
-           Eigen::Vector2d(0.0, beta)));
-
-  const double lift = q_bar_S *
-      (aero_params_.c_lift_alpha.dot(
-           Eigen::Vector4d(1.0, alpha, alpha * alpha, alpha * alpha * alpha)) +
-       aero_params_.c_lift_delta_ail.dot(
-           Eigen::Vector2d(0.0, aileron_sum)) +
-       aero_params_.c_lift_delta_flp.dot(
-           Eigen::Vector2d(0.0, flap_sum)));
-
-  const Eigen::Vector3d forces_Wind(-drag, side_force, -lift);
-
-  // Non-dimensionalize the angular rates for inclusion in the computation of
-  // moments. To avoid division by zero, there is a minimum air speed threshold
-  // below which the values are zero.
-  const double p_hat = (V < kMinAirSpeedThresh) ? 0.0 :
-      p * vehicle_params_.wing_span / (2.0 * V);
-  const double q_hat = (V < kMinAirSpeedThresh) ? 0.0 :
-      q * vehicle_params_.chord_length / (2.0 * V);
-  const double r_hat = (V < kMinAirSpeedThresh) ? 0.0 :
-      r * vehicle_params_.wing_span / (2.0 * V);
-
-  // Compute the moments in the wind frame.
-  const double rolling_moment = q_bar_S * vehicle_params_.wing_span *
-      (aero_params_.c_roll_moment_beta.dot(
-           Eigen::Vector2d(0.0, beta)) +
-       aero_params_.c_roll_moment_p.dot(
-           Eigen::Vector2d(0.0, p_hat)) +
-       aero_params_.c_roll_moment_r.dot(
-           Eigen::Vector2d(0.0, r_hat)) +
-       aero_params_.c_roll_moment_delta_ail.dot(
-           Eigen::Vector2d(0.0, aileron_diff)) +
-       aero_params_.c_roll_moment_delta_flp.dot(
-           Eigen::Vector2d(0.0, flap_diff)));
-
-  const double pitching_moment = q_bar_S * vehicle_params_.chord_length *
-      (aero_params_.c_pitch_moment_alpha.dot(
-           Eigen::Vector2d(1.0, alpha)) +
-       aero_params_.c_pitch_moment_q.dot(
-           Eigen::Vector2d(0.0, q_hat)) +
-       aero_params_.c_pitch_moment_delta_elv.dot(
-           Eigen::Vector2d(0.0, delta_elevator_)));
-
-  const double yawing_moment = q_bar_S * vehicle_params_.wing_span *
-      (aero_params_.c_yaw_moment_beta.dot(
-           Eigen::Vector2d(0.0, beta)) +
-       aero_params_.c_yaw_moment_r.dot(
-           Eigen::Vector2d(0.0, r_hat)) +
-       aero_params_.c_yaw_moment_delta_rud.dot(
-           Eigen::Vector2d(0.0, delta_rudder_)));
-
-  const Eigen::Vector3d moments_Wind(rolling_moment,
-                                     pitching_moment,
-                                     yawing_moment);
-
-  // Compute the thrust force in the body frame.
-  const double thrust = aero_params_.c_thrust.dot(
-      Eigen::Vector3d(1.0, throttle_, throttle_ * throttle_));
-
-  const Eigen::Vector3d force_thrust_B = thrust * Eigen::Vector3d(
-      cos(vehicle_params_.thrust_inclination),
-      0.0,
-      sin(vehicle_params_.thrust_inclination));
-
-  // Compute the transform between the body frame and the wind frame.
-  double ca = cos(alpha);
-  double sa = sin(alpha);
-  double cb = cos(beta);
-  double sb = sin(beta);
-
-  Eigen::Matrix3d R_Wind_B;
-  R_Wind_B << ca * cb, sb, sa * cb,
-              -sb * ca, cb, -sa * sb,
-              -sa, 0.0, ca;
-
-  const Eigen::Matrix3d R_Wind_B_t = R_Wind_B.transpose();
-
-  // Transform all the forces and moments into the body frame
-  const Eigen::Vector3d forces_B = R_Wind_B_t * forces_Wind + force_thrust_B;
-  const Eigen::Vector3d moments_B = R_Wind_B_t * moments_Wind;
+  const Eigen::Vector3d forces_B = parametric_force + residual_force;
+  const Eigen::Vector3d moments_B = parametric_moment + residual_moment;
 
   // Once again account for the difference between our body frame orientation
   // and the traditional aerodynamics frame.

--- a/src/parametric_dynamics_model.cpp
+++ b/src/parametric_dynamics_model.cpp
@@ -1,0 +1,158 @@
+/*
+ * Copyright 2017 Pavel Vechersky, ASL, ETH Zurich, Switzerland
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "parametric_dynamics_model.h"
+
+namespace gazebo {
+
+ParametricDynamicsModel::ParametricDynamicsModel() {
+    aero_params_ = std::make_shared<FWAerodynamicParameters>();
+    vehicle_params_ = std::make_shared<FWVehicleParameters>();
+
+}
+
+ParametricDynamicsModel::~ParametricDynamicsModel() {}
+
+void ParametricDynamicsModel::setState(const ignition::math::Vector3d &B_air_speed_W_B, const ignition::math::Vector3d &B_angular_velocity_W_B, 
+    double delta_aileron_left, double delta_aileron_right, double delta_elevator, double delta_flap, double delta_rudder) {
+  // Traditionally, fixed-wing aerodynamics use NED (North-East-Down) frame,
+  // but since our model's body frame is in North-West-Up frame we rotate the
+  // linear and angular velocities by 180 degrees around the X axis.
+  double u = B_air_speed_W_B.X();
+  double v = -B_air_speed_W_B.Y();
+  double w = -B_air_speed_W_B.Z();
+
+  double p = B_angular_velocity_W_B.X();
+  double q = -B_angular_velocity_W_B.Y();
+  double r = -B_angular_velocity_W_B.Z();
+
+  // Compute the angle of attack (alpha) and the sideslip angle (beta). To
+  // avoid division by zero, there is a minimum air speed threshold below which
+  // alpha and beta are zero.
+  double V = B_air_speed_W_B.Length();
+  double beta = (V < kMinAirSpeedThresh) ? 0.0 : asin(v / V);
+  double alpha = (u < kMinAirSpeedThresh) ? 0.0 : atan(w / u);
+
+  // Bound the angle of attack.
+  if (alpha > aero_params_->alpha_max)
+    alpha = aero_params_->alpha_max;
+  else if (alpha <aero_params_->alpha_min)
+    alpha =aero_params_->alpha_min;
+
+  // Pre-compute the common component in the force and moment calculations.
+  const double q_bar_S = 0.5 * kAirDensity * V * V * vehicle_params_->wing_surface;
+
+  // Combine some of the control surface deflections.
+  double aileron_sum = delta_aileron_left + delta_aileron_right;
+  double aileron_diff = delta_aileron_left - delta_aileron_right;
+  double flap_sum = 2.0 * delta_flap;
+  double flap_diff = 0.0;
+
+  // Compute the forces in the wind frame.
+  const double drag = q_bar_S *
+      (aero_params_->c_drag_alpha.dot(
+           Eigen::Vector3d(1.0, alpha, alpha * alpha)) +
+      aero_params_->c_drag_beta.dot(
+           Eigen::Vector3d(0.0, beta, beta * beta)) +
+      aero_params_->c_drag_delta_ail.dot(
+           Eigen::Vector3d(0.0, aileron_sum, aileron_sum * aileron_sum)) +
+      aero_params_->c_drag_delta_flp.dot(
+           Eigen::Vector3d(0.0, flap_sum, flap_sum * flap_sum)));
+
+  const double side_force = q_bar_S *
+      (aero_params_->c_side_force_beta.dot(
+           Eigen::Vector2d(0.0, beta)));
+
+  const double lift = q_bar_S *
+      (aero_params_->c_lift_alpha.dot(
+           Eigen::Vector4d(1.0, alpha, alpha * alpha, alpha * alpha * alpha)) +
+      aero_params_->c_lift_delta_ail.dot(
+           Eigen::Vector2d(0.0, aileron_sum)) +
+      aero_params_->c_lift_delta_flp.dot(
+           Eigen::Vector2d(0.0, flap_sum)));
+
+  const Eigen::Vector3d forces_Wind(-drag, side_force, -lift);
+
+  // Non-dimensionalize the angular rates for inclusion in the computation of
+  // moments. To avoid division by zero, there is a minimum air speed threshold
+  // below which the values are zero.
+  const double p_hat = (V < kMinAirSpeedThresh) ? 0.0 :
+      p * vehicle_params_->wing_span / (2.0 * V);
+  const double q_hat = (V < kMinAirSpeedThresh) ? 0.0 :
+      q * vehicle_params_->chord_length / (2.0 * V);
+  const double r_hat = (V < kMinAirSpeedThresh) ? 0.0 :
+      r * vehicle_params_->wing_span / (2.0 * V);
+
+  // Compute the moments in the wind frame.
+  const double rolling_moment = q_bar_S * vehicle_params_->wing_span *
+      (aero_params_->c_roll_moment_beta.dot(
+           Eigen::Vector2d(0.0, beta)) +
+      aero_params_->c_roll_moment_p.dot(
+           Eigen::Vector2d(0.0, p_hat)) +
+      aero_params_->c_roll_moment_r.dot(
+           Eigen::Vector2d(0.0, r_hat)) +
+      aero_params_->c_roll_moment_delta_ail.dot(
+           Eigen::Vector2d(0.0, aileron_diff)) +
+      aero_params_->c_roll_moment_delta_flp.dot(
+           Eigen::Vector2d(0.0, flap_diff)));
+
+  const double pitching_moment = q_bar_S * vehicle_params_->chord_length *
+      (aero_params_->c_pitch_moment_alpha.dot(
+           Eigen::Vector2d(1.0, alpha)) +
+      aero_params_->c_pitch_moment_q.dot(
+           Eigen::Vector2d(0.0, q_hat)) +
+      aero_params_->c_pitch_moment_delta_elv.dot(
+           Eigen::Vector2d(0.0, delta_elevator)));
+
+  const double yawing_moment = q_bar_S * vehicle_params_->wing_span *
+      (aero_params_->c_yaw_moment_beta.dot(
+           Eigen::Vector2d(0.0, beta)) +
+      aero_params_->c_yaw_moment_r.dot(
+           Eigen::Vector2d(0.0, r_hat)) +
+      aero_params_->c_yaw_moment_delta_rud.dot(
+           Eigen::Vector2d(0.0, delta_rudder)));
+
+  const Eigen::Vector3d moments_Wind(rolling_moment,
+                                     pitching_moment,
+                                     yawing_moment);
+
+  // Compute the thrust force in the body frame.
+  const double thrust =aero_params_->c_thrust.dot(
+      Eigen::Vector3d(1.0, throttle_, throttle_ * throttle_));
+
+  const Eigen::Vector3d force_thrust_B = thrust * Eigen::Vector3d(
+      cos(vehicle_params_->thrust_inclination),
+      0.0,
+      sin(vehicle_params_->thrust_inclination));
+
+  // Compute the transform between the body frame and the wind frame.
+  double ca = cos(alpha);
+  double sa = sin(alpha);
+  double cb = cos(beta);
+  double sb = sin(beta);
+
+  Eigen::Matrix3d R_Wind_B;
+  R_Wind_B << ca * cb, sb, sa * cb,
+              -sb * ca, cb, -sa * sb,
+              -sa, 0.0, ca;
+
+  const Eigen::Matrix3d R_Wind_B_t = R_Wind_B.transpose();
+
+  // Transform all the forces and moments into the body frame
+  force_ = R_Wind_B_t * forces_Wind + force_thrust_B;
+  moment_ = R_Wind_B_t * moments_Wind;
+}
+}


### PR DESCRIPTION
**Problem Description**
This makes the parametric dynamics into a library, so that we can integrate other force effects (e.g. residual dynamic effects) into the vehicle.

The input / output of the parametric dynamics are as the following. 
- Input: Airspeed in the body frame / Control inputs 
- Output: Aerodynamic forces in the bodyframe

Also noticed that https://github.com/ethz-asl/data-driven-dynamics/pull/28/files was not properly applied to the techpod vehicle, therefore fixed that along the way

**Additional Context**
- Since the original plugin was using ignition math/ gazebo dependencies this had to be linked in the library too. This is something to fix in the future
- This allows us to add the motor model into a single plugin much easier (Not part of this PR)
