### PR TITLE
Flattened model structure and removed

### DIFF
--- a/Tools/parametric_model/generate_parametric_model.py
+++ b/Tools/parametric_model/generate_parametric_model.py
@@ -4,8 +4,8 @@ __maintainer__ = "Manuel Galliker"
 __license__ = "BSD 3"
 
 
-from src.models.simple_quadrotor_model import SimpleQuadRotorModel
-from src.models.quad_plane_model import QuadPlaneModel
+from src.models import SimpleQuadRotorModel
+from src.models import QuadPlaneModel
 import argparse
 
 
@@ -23,7 +23,6 @@ def start_model_estimation(arg_list):
         print("no valid model selected")
 
     model.estimate_model()
-    model.plot_model_prediction()
 
     return
 

--- a/Tools/parametric_model/src/models/__init__.py
+++ b/Tools/parametric_model/src/models/__init__.py
@@ -4,8 +4,11 @@ __author__ = "Manuel Galliker"
 __maintainer__ = "Manuel Galliker"
 __license__ = "BSD 3"
 
-from . import simple_quadrotor_model
 from . import aerodynamic_models
 from . import rotor_models
 from . import model_plots
+from .dynamics_model import DynamicsModel
 from . import quad_plane_model
+from .quad_plane_model import QuadPlaneModel
+from . import simple_quadrotor_model
+from .simple_quadrotor_model import SimpleQuadRotorModel

--- a/Tools/parametric_model/src/models/quad_plane_model.py
+++ b/Tools/parametric_model/src/models/quad_plane_model.py
@@ -10,11 +10,11 @@ import pandas as pd
 import math
 import argparse
 
-from ..dynamics_model import DynamicsModel
-from ..aerodynamic_models import LinearPlateAeroModel
-from ..rotor_models import GazeboRotorModel
+from .dynamics_model import DynamicsModel
+from .aerodynamic_models import LinearPlateAeroModel
+from .rotor_models import GazeboRotorModel
 from sklearn.linear_model import LinearRegression
-from ..model_plots import model_plots, quad_plane_model_plots
+from .model_plots import model_plots, quad_plane_model_plots
 
 
 class QuadPlaneModel(DynamicsModel):

--- a/Tools/parametric_model/src/models/quad_plane_model/__init__.py
+++ b/Tools/parametric_model/src/models/quad_plane_model/__init__.py
@@ -1,2 +1,0 @@
-from . import quad_plane_model
-from .quad_plane_model import QuadPlaneModel

--- a/Tools/parametric_model/src/models/simple_quadrotor_model.py
+++ b/Tools/parametric_model/src/models/simple_quadrotor_model.py
@@ -34,10 +34,10 @@ import math
 import argparse
 
 from sklearn.linear_model import LinearRegression
-from ..dynamics_model import DynamicsModel
-from ..rotor_models import GazeboRotorModel
-from ..model_plots import model_plots
-from ..aerodynamic_models import SimpleDragModel
+from .dynamics_model import DynamicsModel
+from .rotor_models import GazeboRotorModel
+from .model_plots import model_plots
+from .aerodynamic_models import SimpleDragModel
 
 
 class SimpleQuadRotorModel(DynamicsModel):
@@ -94,7 +94,8 @@ class SimpleQuadRotorModel(DynamicsModel):
     def prepare_regression_mat(self):
         self.normalize_actuators()
         self.compute_airspeed()
-        accel_mat = self.data_df[["accelerometer_m_s2[0]", "accelerometer_m_s2[1]", "accelerometer_m_s2[2]"]].to_numpy()
+        accel_mat = self.data_df[[
+            "accelerometer_m_s2[0]", "accelerometer_m_s2[1]", "accelerometer_m_s2[2]"]].to_numpy()
         self.data_df[["ax_body", "ay_body", "az_body"]] = accel_mat
         y = (accel_mat).flatten()
         X_rotor = self.compute_rotor_features()

--- a/Tools/parametric_model/src/models/simple_quadrotor_model/__init__.py
+++ b/Tools/parametric_model/src/models/simple_quadrotor_model/__init__.py
@@ -1,2 +1,0 @@
-from . import simple_quadrotor_model
-from .simple_quadrotor_model import SimpleQuadRotorModel


### PR DESCRIPTION
The Folder structure of the models forlder was adapted to not contain a folder for every model, since we would like to move more into the direction of having one dynamics model which can be configurated by the config file.
Furthermore, the plot_model_prediction was removed from the generate_dynamics_model.py file since it is only present in the simple quadrotor model but not the quadplane model.