### PR TITLE
First pytest to check transformation

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,3 +87,11 @@ Current model choices are:
 - quad_plane_model
 
 The results of the model estimation will be saved into the Tools/parametric_model/results folder as a yaml file.
+
+## Testing the functionality of Parametric model
+
+To ensure that the parametric model works as expected you can perform a set of pytests, which are stored in `Tools/parametric_model/tests`. To start the tests you have to run the shell script:
+
+`Tools/parametric_model/test_parametric_model.sh`
+
+Currently only the transformation from body to intertial frame and vise versa are checked. This should be expanded in the future.

--- a/Tools/parametric_model/__init__.py
+++ b/Tools/parametric_model/__init__.py
@@ -1,1 +1,2 @@
 from . import src
+from . import tests

--- a/Tools/parametric_model/requirements.txt
+++ b/Tools/parametric_model/requirements.txt
@@ -7,5 +7,6 @@ scikit-learn>=0.24.1
 matplotlib>=3.3.4
 PyYAML>=5.4.1
 argparse>=1.4.0
+pytest==6.2.3
 
 

--- a/Tools/parametric_model/src/tools/math_tools.py
+++ b/Tools/parametric_model/src/tools/math_tools.py
@@ -3,6 +3,7 @@ __maintainer__ = "Manuel Galliker"
 __license__ = "BSD 3"
 
 import math
+import numpy as np
 
 
 def sym_sigmoid(x, x_offset=0, scale_fac=1):
@@ -11,3 +12,10 @@ def sym_sigmoid(x, x_offset=0, scale_fac=1):
     y = 1 - (math.exp(scale_fac*(x+x_offset))) / \
         ((1+math.exp(scale_fac*(x-x_offset)))*(1+math.exp(scale_fac*(x+x_offset))))
     return y
+
+
+def rmse_between_numpy_arrays(np_array1, np_array2):
+    difference_array = np.subtract(np_array1, np_array2)
+    squared_array = np.square(difference_array)
+    mse = squared_array.mean()
+    return math.sqrt(mse)

--- a/Tools/parametric_model/test_parametric_model.sh
+++ b/Tools/parametric_model/test_parametric_model.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+
+export PYTHONPATH=$(dirname "$0")
+pytest

--- a/Tools/parametric_model/tests/test_dynamics_model.py
+++ b/Tools/parametric_model/tests/test_dynamics_model.py
@@ -1,0 +1,39 @@
+__author__ = "Manuel Galliker"
+__maintainer__ = "Manuel Galliker"
+__license__ = "BSD 3"
+
+from _pytest.python import Class
+import pytest
+from src.models import DynamicsModel
+from src.tools.math_tools import rmse_between_numpy_arrays
+
+
+def test_transformations():
+    # Setup model with reference log
+    req_topic_dict = {
+        "vehicle_attitude": {"ulog_name": ["timestamp", "q[0]", "q[1]", "q[2]", "q[3]"],
+                             "dataframe_name":  ["timestamp", "q0", "q1", "q2", "q3"]},
+        "vehicle_local_position": {"ulog_name": ["timestamp", "ax", "ay", "az"]},
+        "sensor_combined": {"ulog_name": ["timestamp", "accelerometer_m_s2[0]", "accelerometer_m_s2[1]", "accelerometer_m_s2[2]"]}}
+    model = DynamicsModel(
+        "resources/simple_quadrotor_model.ulg", req_topic_dict, 1)
+
+    # Add gravity vector to inertial accelerations
+    model.data_df["az"] -= 9.81
+
+    # Transform inertial and body matrices to numpy matrices
+    accel_NED_mat = model.data_df[["ax", "ay", "az"]].to_numpy()
+    accel_FRD_mat = model.data_df[[
+        "accelerometer_m_s2[0]", "accelerometer_m_s2[1]", "accelerometer_m_s2[2]"]].to_numpy()
+
+    # Check transform from inertial NED to FRD body frame:
+    accel_NED_transformed_to_FRD = model.rot_to_body_frame(accel_NED_mat)
+    assert (rmse_between_numpy_arrays(
+        accel_FRD_mat, accel_NED_transformed_to_FRD) <= 0.1)
+
+    # Check transform from FRD body frame to inertial NED frame:
+    accel_FRD_transformed_to_NED = model.rot_to_world_frame(accel_FRD_mat)
+    assert (rmse_between_numpy_arrays(
+        accel_NED_mat, accel_FRD_transformed_to_NED) <= 0.1)
+
+    return


### PR DESCRIPTION
A first pytest was added to check the integrity of the transformation methods of the DynamicsModel. Hereby it it load attitude quaternions and acceleration data in both inertial frame and (acceleration - gravity vector) data as measured by the accelerometer in body frame. For this reason also the gravity vector is substracted from the acceleration in inertial frame to achieve comparibal data.

In a next step the two transforms (NED inertial to FRD body frame and vise versa) are applied and the RMSE between the transformed and measured acceleration is computed. The RMSE was observed to be in both cases around 0.078 m/s^2. Therefore, the test for now just thresholds both rmse to be less than 0.1m/s^2.