### PR TITLE
Unified Rotor feature calculation and separate moment and force estimation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ logs*
 .vscode/
 __pycache__/
 resources/model_results/*.yaml
+*.pyc

--- a/Tools/parametric_model/src/models/model_config.py
+++ b/Tools/parametric_model/src/models/model_config.py
@@ -79,3 +79,8 @@ class ModelConfig():
             assert("ulog_name" in topic_type_dict), \
                 print(topic_type, " does not contain an entry for ulog_name")
         return
+
+    def check_estimation_bools(self):
+        # check that at least estimating forces or moments is enabled.
+        assert (self.dynamics_model_config["estimate_forces"] or self.dynamics_model_config["estimate_moments"]), \
+            "Neither estimation of forces or moments is activated in config file."

--- a/Tools/parametric_model/src/models/model_config/config_template.yaml
+++ b/Tools/parametric_model/src/models/model_config/config_template.yaml
@@ -35,6 +35,8 @@ model_config:
 
 # the data configuration is used in dynamics_model.py to load and arrange the data
 dynamics_model_config:
+  estimate_forces: True
+  estimate_moments: False
   resample_freq: 100.0
   data:
     required_ulog_topics: # only used when load_from_csv = False

--- a/Tools/parametric_model/src/models/model_config/dynamics_model_test_config.yaml
+++ b/Tools/parametric_model/src/models/model_config/dynamics_model_test_config.yaml
@@ -35,6 +35,8 @@ model_config:
 
 # the data configuration is used in dynamics_model.py to load and arrange the data
 dynamics_model_config:
+  estimate_forces: True
+  estimate_moments: False
   resample_freq: 100.0
   data:
     required_ulog_topics:

--- a/Tools/parametric_model/src/models/model_config/qpm_delta_vtol_config.yaml
+++ b/Tools/parametric_model/src/models/model_config/qpm_delta_vtol_config.yaml
@@ -9,70 +9,72 @@ model_file:
 model_config:
   actuators:
     rotors:
-      - rotor_0:
-        description: "front right rotor"
-        dataframe_name: "u0"
-        rotor_axis:
-          - 0
-          - 0
-          - -1
-        turning_direction: -1
-        position:
-          - 0.35
-          - 0.35
-          - -0.07
+      # All rotors in the same group will share the coefficients
+      vertical_:
+        - rotor_0:
+          description: "front right rotor"
+          dataframe_name: "u0"
+          rotor_axis:
+            - 0
+            - 0
+            - -1
+          turning_direction: -1
+          position:
+            - 0.35
+            - 0.35
+            - -0.07
 
-      - rotor_1:
-        description: "back left rotor"
-        dataframe_name: "u1"
-        rotor_axis:
-          - 0
-          - 0
-          - -1
-        turning_direction: -1
-        position:
-          - -0.35
-          - -0.35
-          - -0.07
+        - rotor_1:
+          description: "back left rotor"
+          dataframe_name: "u1"
+          rotor_axis:
+            - 0
+            - 0
+            - -1
+          turning_direction: -1
+          position:
+            - -0.35
+            - -0.35
+            - -0.07
 
-      - rotor_2:
-        description: "front left rotor"
-        dataframe_name: "u2"
-        rotor_axis:
-          - 0
-          - 0
-          - -1
-        turning_direction: 1
-        position:
-          - 0.35
-          - -0.35
-          - -0.07
+        - rotor_2:
+          description: "front left rotor"
+          dataframe_name: "u2"
+          rotor_axis:
+            - 0
+            - 0
+            - -1
+          turning_direction: 1
+          position:
+            - 0.35
+            - -0.35
+            - -0.07
 
-      - rotor_3:
-        description: "back right rotor"
-        dataframe_name: "u3"
-        rotor_axis:
-          - 0
-          - 0
-          - -1
-        turning_direction: 1
-        position:
-          - -0.35
-          - 0.35
-          - -0.07
-
-      - rotor_4:
-        description: "puller rotor"
-        dataframe_name: "u4"
-        rotor_axis:
-          - 1
-          - 0
-          - 0
-        turning_direction: -1
-        position:
-          - 0.22
-          - 0
-          - 0
+        - rotor_3:
+          description: "back right rotor"
+          dataframe_name: "u3"
+          rotor_axis:
+            - 0
+            - 0
+            - -1
+          turning_direction: 1
+          position:
+            - -0.35
+            - 0.35
+            - -0.07
+      puller_:
+        - rotor_4:
+          description: "puller rotor"
+          dataframe_name: "u4"
+          rotor_axis:
+            - 1
+            - 0
+            - 0
+          turning_direction: -1
+          position:
+            - 0.22
+            - 0
+            - 0
 
     control_surfaces:
       - control_surface_0:
@@ -88,7 +90,9 @@ model_config:
     sig_scale_factor: 30
 
 dynamics_model_config:
-  resample_freq: 100.0
+  estimate_forces: True
+  estimate_moments: False
+  resample_freq: 1.0
   data:
     required_ulog_topics:
       actuator_outputs:

--- a/Tools/parametric_model/src/models/model_config/qpm_gazebo_standard_vtol_config.yaml
+++ b/Tools/parametric_model/src/models/model_config/qpm_gazebo_standard_vtol_config.yaml
@@ -9,70 +9,72 @@ model_file:
 model_config:
   actuators:
     rotors:
-      - rotor_0:
-        description: "front right rotor"
-        dataframe_name: "u0"
-        rotor_axis:
-          - 0
-          - 0
-          - -1
-        turning_direction: -1
-        position:
-          - 0.35
-          - 0.35
-          - -0.07
+      # All rotors in the same group will share the coefficients
+      vertical_:
+        - rotor_0:
+          description: "front right rotor"
+          dataframe_name: "u0"
+          rotor_axis:
+            - 0
+            - 0
+            - -1
+          turning_direction: -1
+          position:
+            - 0.35
+            - 0.35
+            - -0.07
 
-      - rotor_1:
-        description: "back left rotor"
-        dataframe_name: "u1"
-        rotor_axis:
-          - 0
-          - 0
-          - -1
-        turning_direction: -1
-        position:
-          - -0.35
-          - -0.35
-          - -0.07
+        - rotor_1:
+          description: "back left rotor"
+          dataframe_name: "u1"
+          rotor_axis:
+            - 0
+            - 0
+            - -1
+          turning_direction: -1
+          position:
+            - -0.35
+            - -0.35
+            - -0.07
 
-      - rotor_2:
-        description: "front left rotor"
-        dataframe_name: "u2"
-        rotor_axis:
-          - 0
-          - 0
-          - -1
-        turning_direction: 1
-        position:
-          - 0.35
-          - -0.35
-          - -0.07
+        - rotor_2:
+          description: "front left rotor"
+          dataframe_name: "u2"
+          rotor_axis:
+            - 0
+            - 0
+            - -1
+          turning_direction: 1
+          position:
+            - 0.35
+            - -0.35
+            - -0.07
 
-      - rotor_3:
-        description: "back right rotor"
-        dataframe_name: "u3"
-        rotor_axis:
-          - 0
-          - 0
-          - -1
-        turning_direction: 1
-        position:
-          - -0.35
-          - 0.35
-          - -0.07
-
-      - rotor_4:
-        description: "puller rotor"
-        dataframe_name: "u4"
-        rotor_axis:
-          - 1
-          - 0
-          - 0
-        turning_direction: -1
-        position:
-          - 0.22
-          - 0
-          - 0
+        - rotor_3:
+          description: "back right rotor"
+          dataframe_name: "u3"
+          rotor_axis:
+            - 0
+            - 0
+            - -1
+          turning_direction: 1
+          position:
+            - -0.35
+            - 0.35
+            - -0.07
+      puller_:
+        - rotor_4:
+          description: "puller rotor"
+          dataframe_name: "u4"
+          rotor_axis:
+            - 1
+            - 0
+            - 0
+          turning_direction: -1
+          position:
+            - 0.22
+            - 0
+            - 0
 
     control_surfaces:
       - control_surface_0:
@@ -92,6 +94,8 @@ model_config:
     sig_scale_factor: 30
 
 dynamics_model_config:
+  estimate_forces: True
+  estimate_moments: True
   resample_freq: 100.0
   data:
     required_ulog_topics:

--- a/Tools/parametric_model/src/models/model_config/sqrm_gazebo_standart_config.yaml
+++ b/Tools/parametric_model/src/models/model_config/sqrm_gazebo_standart_config.yaml
@@ -9,59 +9,62 @@ model_file:
 model_config:
   actuators:
     rotors:
-      - rotor_0:
-        description: "front right rotor"
-        dataframe_name: "u0"
-        rotor_axis:
-          - 0
-          - 0
-          - -1
-        turning_direction: -1
-        position:
-          - 0.13
-          - 0.22
-          - -0.023
+      vertical_:
+        - rotor_0:
+          description: "front right rotor"
+          dataframe_name: "u0"
+          rotor_axis:
+            - 0
+            - 0
+            - -1
+          turning_direction: -1
+          position:
+            - 0.13
+            - 0.22
+            - -0.023
 
-      - rotor_1:
-        description: "back left rotor"
-        dataframe_name: "u1"
-        rotor_axis:
-          - 0
-          - 0
-          - -1
-        turning_direction: -1
-        position:
-          - -0.13
-          - -0.2
-          - -0.023
+        - rotor_1:
+          description: "back left rotor"
+          dataframe_name: "u1"
+          rotor_axis:
+            - 0
+            - 0
+            - -1
+          turning_direction: -1
+          position:
+            - -0.13
+            - -0.2
+            - -0.023
 
-      - rotor_2:
-        description: "front left rotor"
-        dataframe_name: "u2"
-        rotor_axis:
-          - 0
-          - 0
-          - -1
-        turning_direction: 1
-        position:
-          - 0.13
-          - -0.2
-          - -0.023
+        - rotor_2:
+          description: "front left rotor"
+          dataframe_name: "u2"
+          rotor_axis:
+            - 0
+            - 0
+            - -1
+          turning_direction: 1
+          position:
+            - 0.13
+            - -0.2
+            - -0.023
 
-      - rotor_3:
-        description: "back right rotor"
-        dataframe_name: "u3"
-        rotor_axis:
-          - 0
-          - 0
-          - -1
-        turning_direction: 1
-        position:
-          - -0.13
-          - 0.2
-          - -0.023
+        - rotor_3:
+          description: "back right rotor"
+          dataframe_name: "u3"
+          rotor_axis:
+            - 0
+            - 0
+            - -1
+          turning_direction: 1
+          position:
+            - -0.13
+            - 0.2
+            - -0.023
 
 dynamics_model_config:
+  estimate_forces: True
+  estimate_moments: False
   resample_freq: 100.0
   data:
     required_ulog_topics:

--- a/Tools/parametric_model/src/models/quad_plane_model.py
+++ b/Tools/parametric_model/src/models/quad_plane_model.py
@@ -18,71 +18,19 @@ from .model_config import ModelConfig
 from .aerodynamic_models import AeroModelAAE
 
 
+"""This model estimates forces and moments for quad plane as for example the standard vtol in gazebo."""
+
+
 class QuadPlaneModel(DynamicsModel):
     def __init__(self, rel_data_path, config_file="qpm_gazebo_standard_vtol_config.yaml"):
         self.config = ModelConfig(config_file)
         super(QuadPlaneModel, self).__init__(
             config_dict=self.config.dynamics_model_config, rel_data_path=rel_data_path)
 
-        self.rotor_config_list = self.config.model_config["actuators"]["rotors"]
-        self.rotor_count = len(self.rotor_config_list)
+        self.rotor_config_dict = self.config.model_config["actuators"]["rotors"]
         self.stall_angle = math.pi/180 * \
             self.config.model_config["aerodynamics"]["stall_angle_deg"]
         self.sig_scale_fac = self.config.model_config["aerodynamics"]["sig_scale_factor"]
-
-    def compute_rotor_features(self):
-        u_mat = self.data_df[["u0", "u1", "u2", "u3", "u4"]].to_numpy()
-        v_airspeed_mat = self.data_df[[
-            "V_air_body_x", "V_air_body_y", "V_air_body_z"]].to_numpy()
-
-        # Vertical Rotor Features
-        # all vertical rotors are assumed to have the same rotor parameters, therefore their feature matrices are added.
-        for i in range((self.rotor_count-1)):
-            print("Starting computation of rotor features for rotor: ", i)
-            rotor_dict = self.rotor_config_list[i]
-            rotor_axis = np.array(rotor_dict["rotor_axis"])
-            rotor_position = np.array(rotor_dict["position"])
-            currActuator = RotorModel(
-                rotor_axis, rotor_position, rotor_dict["turning_direction"])
-            X_force_curr, X_moment_curr, vert_rotor_forces_coef_list, vert_rotor_moments_coef_list = currActuator.compute_actuator_feature_matrix(
-                u_mat[:, i], v_airspeed_mat)
-            if 'X_vert_rot_forces' in vars():
-                X_vert_rot_forces += X_force_curr
-                X_vert_rot_moments += X_moment_curr
-            else:
-                X_vert_rot_forces = X_force_curr
-                X_vert_rot_moments = X_moment_curr
-        for i in range(len(vert_rotor_forces_coef_list)):
-            vert_rotor_forces_coef_list[i] = "vert_" + \
-                vert_rotor_forces_coef_list[i]
-        for i in range(len(vert_rotor_moments_coef_list)):
-            vert_rotor_moments_coef_list[i] = "vert_" + \
-                vert_rotor_moments_coef_list[i]
-
-        # Horizontal Rotor Features
-        print("Starting computation of rotor features for rotor: ", 4)
-        rotor_dict = self.rotor_config_list[4]
-        rotor_axis = np.array(rotor_dict["rotor_axis"])
-        rotor_position = np.array(rotor_dict["position"])
-        forwardActuator = RotorModel(
-            rotor_axis, rotor_position, rotor_dict["turning_direction"])
-        X_hor_rot_forces, X_hor_rot_moments, hor_rotor_forces_coef_list, hor_rotor_moments_coef_list = forwardActuator.compute_actuator_feature_matrix(
-            u_mat[:, 4], v_airspeed_mat)
-        for i in range(len(hor_rotor_forces_coef_list)):
-            hor_rotor_forces_coef_list[i] = "horizontal_" + \
-                hor_rotor_forces_coef_list[i]
-        for i in range(len(hor_rotor_moments_coef_list)):
-            hor_rotor_moments_coef_list[i] = "horizontal_" + \
-                hor_rotor_moments_coef_list[i]
-
-        # Combine all rotor feature matrices
-        X_rotor_forces = np.hstack(
-            (X_vert_rot_forces, X_hor_rot_forces))
-        X_rotor_moments = np.hstack(
-            (X_vert_rot_moments, X_hor_rot_moments))
-        rotor_forces_coef_list = vert_rotor_forces_coef_list + hor_rotor_forces_coef_list
-        rotor_moments_coef_list = vert_rotor_moments_coef_list + hor_rotor_moments_coef_list
-        return X_rotor_forces, X_rotor_moments, rotor_forces_coef_list, rotor_moments_coef_list
 
     def prepare_regression_matrices(self):
 
@@ -91,41 +39,56 @@ class QuadPlaneModel(DynamicsModel):
             self.compute_airspeed_from_groundspeed(["vx", "vy", "vz"])
 
         # Rotor features
-        X_rotor_forces, X_rotor_moments, rotor_forces_coef_list, rotor_moments_coef_list = self.compute_rotor_features()
+        self.compute_rotor_features(self.rotor_config_dict)
 
-        # Aerodynamics features
-        airspeed_mat = self.data_df[["V_air_body_x",
-                                     "V_air_body_y", "V_air_body_z"]].to_numpy()
-        flap_commands = self.data_df[["u5", "u6", "u7"]].to_numpy()
-        aoa_mat = self.data_df[["AoA"]].to_numpy()
-        aero_model = AeroModelAAE(
-            stall_angle=20.0, sig_scale_fac=self.sig_scale_fac)
-        X_aero_forces, aero_coef_list = aero_model.compute_aero_features(
-            airspeed_mat, aoa_mat, flap_commands)
+        if (self.estimate_forces):
+            # Aerodynamics features
+            airspeed_mat = self.data_df[["V_air_body_x",
+                                        "V_air_body_y", "V_air_body_z"]].to_numpy()
+            flap_commands = self.data_df[["u5", "u6", "u7"]].to_numpy()
+            aoa_mat = self.data_df[["AoA"]].to_numpy()
+            aero_model = AeroModelAAE(
+                stall_angle=self.stall_angle, sig_scale_fac=self.sig_scale_fac)
+            X_aero_forces, aero_coef_list = aero_model.compute_aero_features(
+                airspeed_mat, aoa_mat, flap_commands)
+            self.X_forces = np.hstack((self.X_rotor_forces, X_aero_forces))
+            X = self.X_forces
 
-        # features due to rotation of body frame
-        X_body_rot_moment, X_body_rot_moment_coef_list = self.compute_body_rotation_features(
-            ["ang_vel_x", "ang_vel_y", "ang_vel_z"])
+            # Accelerations
+            accel_body_mat = self.data_df[[
+                "accelerometer_m_s2[0]", "accelerometer_m_s2[1]", "accelerometer_m_s2[2]"]].to_numpy()
+            self.y_forces = accel_body_mat.flatten()
+            y = self.y_forces
 
-        # Concat features
-        X_forces = np.hstack((X_rotor_forces, X_aero_forces))
-        X_moments = np.hstack((X_rotor_moments, X_body_rot_moment))
-        X = block_diag(X_forces, X_moments)
-        self.coef_name_list.extend(rotor_forces_coef_list + aero_coef_list +
-                                   rotor_moments_coef_list + X_body_rot_moment_coef_list)
-        # define separate features for plotting
-        self.X_forces = X[0:X_forces.shape[0], :]
-        self.X_moments = X[X_forces.shape[0]:X.shape[0], :]
+            # Set coefficients
+            self.coef_name_list.extend(
+                self.rotor_forces_coef_list + aero_coef_list)
 
-        # prepare linear and angular accelerations as regressand for forces
-        accel_body_mat = self.data_df[[
-            "accelerometer_m_s2[0]", "accelerometer_m_s2[1]", "accelerometer_m_s2[2]"]].to_numpy()
-        angular_accel_body_mat = self.data_df[[
-            "ang_acc_x", "ang_acc_y", "ang_acc_z"]].to_numpy()
-        # define separate features for plotting
-        self.y_forces = accel_body_mat.flatten()
-        self.y_moments = angular_accel_body_mat.flatten()
-        y = np.hstack((self.y_forces, self.y_moments))
+        if (self.estimate_moments):
+            # features due to rotation of body frame
+            X_body_rot_moment, X_body_rot_moment_coef_list = self.compute_body_rotation_features(
+                ["ang_vel_x", "ang_vel_y", "ang_vel_z"])
+            self.X_moments = np.hstack(
+                (self.X_rotor_moments, X_body_rot_moment))
+            X = self.X_moments
+
+            # Angular acceleration
+            angular_accel_body_mat = self.data_df[[
+                "ang_acc_x", "ang_acc_y", "ang_acc_z"]].to_numpy()
+            self.y_moments = angular_accel_body_mat.flatten()
+            y = self.y_moments
+
+            # Set coefficients
+            self.coef_name_list.extend(
+                self.rotor_moments_coef_list + X_body_rot_moment_coef_list)
+
+        if (self.estimate_forces and self.estimate_moments):
+            X = block_diag(self.X_forces, self.X_moments)
+            y = np.hstack((self.y_forces, self.y_moments))
+
+            # define separate features for plotting and predicitons
+            self.X_forces = X[0:self.X_forces.shape[0], :]
+            self.X_moments = X[self.X_forces.shape[0]:X.shape[0], :]
 
         return X, y
 

--- a/Tools/parametric_model/src/models/rotor_models/rotor_model.py
+++ b/Tools/parametric_model/src/models/rotor_models/rotor_model.py
@@ -9,13 +9,35 @@ from progress.bar import Bar
 
 
 class RotorModel():
-    def __init__(self, rotor_axis=np.array([[0], [0], [-1]]), rotor_position=np.array([[1], [1], [0]]), turning_direction=1):
+    def __init__(self, rotor_config_dict):
         # no more thrust produced at this airspeed inflow velocity
-        self.rotor_axis = rotor_axis.reshape(3, 1)
-        self.rotor_position = rotor_position.reshape(3, 1)
-        self.turning_direction = turning_direction
+        self.rotor_axis = np.array(
+            rotor_config_dict["rotor_axis"]).reshape(3, 1)
+        self.rotor_position = np.array(
+            rotor_config_dict["position"]).reshape(3, 1)
+        self.turning_direction = rotor_config_dict["turning_direction"]
+        self.rotor_name = rotor_config_dict["description"]
 
-    def compute_actuator_force_features(self, actuator_input, v_airspeed):
+    def initialize_actuator_airspeed(self, v_airspeed_mat):
+
+        self.v_airspeed_parallel_to_rotor_axis = np.zeros(
+            v_airspeed_mat.shape)
+        self.v_air_parallel_abs = np.zeros(v_airspeed_mat.shape[0])
+        self.v_airspeed_perpendicular_to_rotor_axis = np.zeros(
+            v_airspeed_mat.shape)
+
+        for i in range(v_airspeed_mat.shape[0]):
+            v_airspeed = v_airspeed_mat[i, :]
+            self.v_airspeed_parallel_to_rotor_axis[i, :] = (np.vdot(
+                self.rotor_axis, v_airspeed) * self.rotor_axis).flatten()
+            self.v_air_parallel_abs[i] = np.linalg.norm(
+                self.v_airspeed_parallel_to_rotor_axis)
+            self.v_airspeed_perpendicular_to_rotor_axis[i, :] = v_airspeed - \
+                self.v_airspeed_parallel_to_rotor_axis[i, :]
+
+        self.airspeed_initialized = True
+
+    def compute_actuator_force_features(self, actuator_input, v_air_parallel_abs, v_airspeed_perpendicular_to_rotor_axis):
         """compute thrust model using a 2nd degree model of the normalized actuator outputs
 
         Inputs:
@@ -26,15 +48,10 @@ class RotorModel():
         """
 
         # Thrust force computation
-        v_airspeed_parallel_to_rotor_axis = np.vdot(
-            self.rotor_axis, v_airspeed) * self.rotor_axis
-        v_air_parallel = np.linalg.norm(v_airspeed_parallel_to_rotor_axis)
 
         X_thrust = self.rotor_axis @ np.array(
-            [[actuator_input**2, (actuator_input*v_air_parallel)]])
+            [[actuator_input**2, (actuator_input*v_air_parallel_abs)]])
         # Drag force computation
-        v_airspeed_perpendicular_to_rotor_axis = v_airspeed - \
-            v_airspeed_parallel_to_rotor_axis
         if (np.linalg.norm(v_airspeed_perpendicular_to_rotor_axis) >= 0.05):
             X_drag = - v_airspeed_perpendicular_to_rotor_axis @ np.array(
                 [[actuator_input]])
@@ -43,44 +60,74 @@ class RotorModel():
 
         X_forces = np.hstack((X_drag, X_thrust))
 
+        return X_forces
+
+    def compute_actuator_moment_features(self, actuator_input, v_air_parallel_abs, v_airspeed_perpendicular_to_rotor_axis):
+
         X_moments = np.zeros((3, 5))
 
         leaver_moment_vec = np.cross(
             self.rotor_position.flatten(), self.rotor_axis.flatten())
         # Thrust leaver moment
         X_moments[:, 0] = leaver_moment_vec * actuator_input**2
-        X_moments[:, 1] = leaver_moment_vec * actuator_input*v_air_parallel
+        X_moments[:, 1] = leaver_moment_vec * \
+            actuator_input*v_air_parallel_abs
 
         # Rotor drag moment
         X_moments[2, 2] = - self.turning_direction * actuator_input**2
         X_moments[2, 3] = - self.turning_direction * \
-            actuator_input*v_air_parallel
+            actuator_input*v_air_parallel_abs
 
         # Rotor Rolling Moment
         X_moments[:, 4] = -1 * v_airspeed_perpendicular_to_rotor_axis.flatten() * \
             self.turning_direction * actuator_input
 
-        return X_forces, X_moments
+        return X_moments
 
-    def compute_actuator_feature_matrix(self, actuator_input_vec, v_airspeed_mat):
+    def compute_actuator_force_matrix(self, actuator_input_vec):
         """
         Inputs:
         actuator_input_vec: vector of actuator inputs (normalized between 0 and 1), numpy array of shape (n, 1)
         v_airspeed_mat: matrix of vertically stacked airspeed vectors, numpy array of shape (n, 3)
         """
-        X_forces, X_moments = self.compute_actuator_force_features(
-            actuator_input_vec[0], v_airspeed_mat[0, :].reshape((3, 1)))
+        assert (self.airspeed_initialized), "Airspeed is not initialized. Call initialize_actuator_airspeed(v_airspeed_mat) first."
+
+        print("Computing force features for rotor:", self.rotor_name)
+
+        X_forces = self.compute_actuator_force_features(
+            actuator_input_vec[0], self.v_air_parallel_abs[0], self.v_airspeed_perpendicular_to_rotor_axis[0, :].reshape((3, 1)))
         rotor_features_bar = Bar(
             'Feature Computatiuon', max=actuator_input_vec.shape[0])
         for i in range(1, actuator_input_vec.shape[0]):
-            X_force_curr, X_moment_curr = self.compute_actuator_force_features(
-                actuator_input_vec[i], v_airspeed_mat[i, :].reshape((3, 1)))
+            X_force_curr = self.compute_actuator_force_features(
+                actuator_input_vec[i], self.v_air_parallel_abs[i], self.v_airspeed_perpendicular_to_rotor_axis[i, :].reshape((3, 1)))
             X_forces = np.vstack((X_forces, X_force_curr))
-            X_moments = np.vstack((X_moments, X_moment_curr))
             rotor_features_bar.next()
         rotor_features_bar.finish()
         coef_list_forces = ["rot_drag_lin", "rot_thrust_quad",
                             "rot_thrust_lin"]
+        return X_forces, coef_list_forces
+
+    def compute_actuator_moment_matrix(self, actuator_input_vec):
+        """
+        Inputs:
+        actuator_input_vec: vector of actuator inputs (normalized between 0 and 1), numpy array of shape (n, 1)
+        v_airspeed_mat: matrix of vertically stacked airspeed vectors, numpy array of shape (n, 3)
+        """
+        assert (self.airspeed_initialized), "Airspeed is not initialized. Call initialize_actuator_airspeed(v_airspeed_mat) first."
+
+        print("Computing moment features for rotor:", self.rotor_name)
+
+        X_moments = self.compute_actuator_moment_features(
+            actuator_input_vec[0], self.v_air_parallel_abs[0], self.v_airspeed_perpendicular_to_rotor_axis[0, :].reshape((3, 1)))
+        rotor_features_bar = Bar(
+            'Feature Computatiuon', max=actuator_input_vec.shape[0])
+        for i in range(1, actuator_input_vec.shape[0]):
+            X_moment_curr = self.compute_actuator_moment_features(
+                actuator_input_vec[i], self.v_air_parallel_abs[i], self.v_airspeed_perpendicular_to_rotor_axis[i, :].reshape((3, 1)))
+            X_moments = np.vstack((X_moments, X_moment_curr))
+            rotor_features_bar.next()
+        rotor_features_bar.finish()
         coef_list_moments = ["c_m_leaver_quad", "c_m_leaver_lin",
                              "c_m_drag_z_quad", "c_m_drag_z_lin", "c_m_rolling"]
-        return X_forces, X_moments, coef_list_forces, coef_list_moments
+        return X_moments, coef_list_moments


### PR DESCRIPTION
### Overview

Before adding still another model i decided to quickly unify the rotor feature calculation to keep law & order and help with the development of the new model. Furthermore, I think it is helpful to being able to choose to only estimate forces or estimate both in the config file to focus on forces at the moment, but keep the options open for the future.  


![image](https://user-images.githubusercontent.com/18735094/117462122-98c09580-af4e-11eb-9fc9-3e1d6d5e6604.png)

### Commit Description

In this commit the calculation of the rotor features was moved to a method in the dynamics model and is therefore now unified between all the models. The user can configure rotor groups in the config file of his model. Hereby, all rotors from the same group are assumed to be physically (motor, prop, voltage, ect.) equal and will share all coefficients as determined by the parametric model.

Furthermore, i decided to allow the user to configure whether forces, moments or both are estimated by the algorithm. This was combined with the changes mentioned above since the rotor force and moment features share a significant part of the computation. In particular both need to compute the airplow parallel and perpendicular to the rotor axis for each timestamp. With the current implementation those computations are shared when both are activated which results in much faster performance for large datasets.