### PR TITLE
Adding submodule dependencies to CI

### DIFF
--- a/.github/workflows/sysid_test.yml
+++ b/.github/workflows/sysid_test.yml
@@ -21,6 +21,8 @@ jobs:
       - uses: actions/checkout@v1
       - name: submodule update
         run: git submodule update --init --recursive
+      - name: Install submodule python dependencies
+        run: pip3 install -r Tools/parametric_model/visual_dataframe_selector/requirements.txt
       - name: Install python dependencies
         run: pip3 install -r Tools/parametric_model/requirements.txt
       - name: Run subsystem level tests on parametric model


### PR DESCRIPTION
In the last PR the SysID test failed due to the dependencies of the submodule not being installed. This is fixed now by using the same command as specified in the readme.