### PR TITLE
Explicitly load ulogs and not in constructor of dynamic models

### DIFF
--- a/Tools/parametric_model/generate_parametric_model.py
+++ b/Tools/parametric_model/generate_parametric_model.py
@@ -21,25 +21,25 @@ def str2bool(v):
 
 
 def start_model_estimation(arg_list):
-    rel_ulog_path = arg_list.log_path
     model = arg_list.model
     data_selection_enabled = arg_list.data_selection
     print("Visual Data selection enabled: ", data_selection_enabled)
 
     if (model == "quadrotor_model"):
-        model = QuadRotorModel(rel_ulog_path)
+        model = QuadRotorModel()
 
     elif (model == "quad_plane_model"):
-        model = QuadPlaneModel(rel_ulog_path)
+        model = QuadPlaneModel()
 
     elif (model == "delta_quad_plane_model"):
-        model = DeltaQuadPlaneModel(rel_ulog_path)
+        model = DeltaQuadPlaneModel()
 
     elif (model == "tilt_wing_model"):
-        model = TiltWingModel(rel_ulog_path)
-
+        model = TiltWingModel()
     else:
         print("no valid model selected")
+    
+    model.loadLog(arg_list.log_path)
 
     if data_selection_enabled:
         model.visually_select_data()

--- a/Tools/parametric_model/src/models/delta_quad_plane_model.py
+++ b/Tools/parametric_model/src/models/delta_quad_plane_model.py
@@ -21,10 +21,10 @@ import matplotlib.pyplot as plt
 
 
 class DeltaQuadPlaneModel(DynamicsModel):
-    def __init__(self, rel_data_path, config_file="qpm_delta_vtol_config.yaml"):
+    def __init__(self, config_file="qpm_delta_vtol_config.yaml"):
         self.config = ModelConfig(config_file)
         super(DeltaQuadPlaneModel, self).__init__(
-            config_dict=self.config.dynamics_model_config, rel_data_path=rel_data_path)
+            config_dict=self.config.dynamics_model_config)
 
         self.rotor_config_dict = self.config.model_config["actuators"]["rotors"]
         self.stall_angle = math.pi/180 * \

--- a/Tools/parametric_model/src/models/dynamics_model.py
+++ b/Tools/parametric_model/src/models/dynamics_model.py
@@ -19,7 +19,7 @@ from src.tools.quat_utils import quaternion_to_rotation_matrix
 
 
 class DynamicsModel():
-    def __init__(self, config_dict, rel_data_path):
+    def __init__(self, config_dict):
 
         assert type(
             config_dict) is dict, 'req_topics_dict input must be a dict'
@@ -29,7 +29,6 @@ class DynamicsModel():
         print("Resample frequency: ", self.resample_freq, "Hz")
         self.req_topics_dict = config_dict["data"]["required_ulog_topics"]
         self.req_dataframe_topic_list = config_dict["data"]["req_dataframe_topic_list"]
-        self.rel_data_path = rel_data_path
 
         self.visual_dataframe_selector_config_dict = {
             "x_axis_col": "timestamp",
@@ -38,6 +37,12 @@ class DynamicsModel():
 
         self.estimate_forces = config_dict["estimate_forces"]
         self.estimate_moments = config_dict["estimate_moments"]
+
+        # used to generate a dict with the resulting coefficients later on.
+        self.coef_name_list = []
+        self.result_dict = {}
+    def loadLog(self, rel_data_path):
+        self.rel_data_path = rel_data_path
 
         if (rel_data_path[-4:] == ".csv"):
             self.data_df = pd.read_csv(rel_data_path, index_col=0)
@@ -60,10 +65,6 @@ class DynamicsModel():
         self.n_samples = self.data_df.shape[0]
         self.quaternion_df = self.data_df[["q0", "q1", "q2", "q3"]]
         self.q_mat = self.quaternion_df.to_numpy()
-
-        # used to generate a dict with the resulting coefficients later on.
-        self.coef_name_list = []
-        self.result_dict = {}
 
     def check_ulog_for_req_topics(self):
         for topic_type in self.req_topics_dict.keys():

--- a/Tools/parametric_model/src/models/quad_plane_model.py
+++ b/Tools/parametric_model/src/models/quad_plane_model.py
@@ -23,10 +23,10 @@ import matplotlib.pyplot as plt
 
 
 class QuadPlaneModel(DynamicsModel):
-    def __init__(self, rel_data_path, config_file="qpm_gazebo_standard_vtol_config.yaml"):
+    def __init__(self, config_file="qpm_gazebo_standard_vtol_config.yaml"):
         self.config = ModelConfig(config_file)
         super(QuadPlaneModel, self).__init__(
-            config_dict=self.config.dynamics_model_config, rel_data_path=rel_data_path)
+            config_dict=self.config.dynamics_model_config)
 
         self.rotor_config_dict = self.config.model_config["actuators"]["rotors"]
         self.stall_angle = math.pi/180 * \

--- a/Tools/parametric_model/src/models/quadrotor_model.py
+++ b/Tools/parametric_model/src/models/quadrotor_model.py
@@ -41,10 +41,10 @@ import matplotlib.pyplot as plt
 
 
 class QuadRotorModel(DynamicsModel):
-    def __init__(self, rel_data_path, config_file="sqrm_gazebo_standart_config.yaml"):
+    def __init__(self, config_file="sqrm_gazebo_standart_config.yaml"):
         self.config = ModelConfig(config_file)
         super(QuadRotorModel, self).__init__(
-            config_dict=self.config.dynamics_model_config, rel_data_path=rel_data_path)
+            config_dict=self.config.dynamics_model_config)
         self.rotor_config_dict = self.config.model_config["actuators"]["rotors"]
 
         assert (self.estimate_moments ==

--- a/Tools/parametric_model/src/models/tilt_wing_model.py
+++ b/Tools/parametric_model/src/models/tilt_wing_model.py
@@ -24,10 +24,10 @@ import matplotlib.pyplot as plt
 
 
 class TiltWingModel(DynamicsModel):
-    def __init__(self, rel_data_path, config_file="tilt_wing_config.yaml"):
+    def __init__(self, config_file="tilt_wing_config.yaml"):
         self.config = ModelConfig(config_file)
         super(TiltWingModel, self).__init__(
-            config_dict=self.config.dynamics_model_config, rel_data_path=rel_data_path)
+            config_dict=self.config.dynamics_model_config)
 
         self.rotor_config_dict = self.config.model_config["actuators"]["rotors"]
         self.stall_angle = math.pi/180 * \

--- a/Tools/parametric_model/tests/test_dynamics_model.py
+++ b/Tools/parametric_model/tests/test_dynamics_model.py
@@ -12,8 +12,9 @@ from src.tools.math_tools import rmse_between_numpy_arrays
 def test_transformations(config_file="dynamics_model_test_config.yaml"):
     # Setup model with reference log
     config = ModelConfig(config_file)
-    model = DynamicsModel(config_dict=config.dynamics_model_config,
-                          rel_data_path="resources/quadrotor_model.ulg")
+    model = DynamicsModel(config_dict=config.dynamics_model_config)
+
+    model.loadLog("resources/quadrotor_model.ulg")
 
     # Add gravity vector to inertial accelerations
     model.data_df["az"] -= 9.81


### PR DESCRIPTION
**Problem Description**
Currently the dynamics model class is a single class that defines data pre-processing, model definitions and also a regression pipeline. IMHO, it would be better if we can separate these three functions into different objects so that we don't create dependencies that are not semantic (e.g. regression pipeline as being part of a model)

This commit separates out ulog loading outside the constructor, so that models can be constructed without a ulog file.
This is a minor refactor in order to separate model construction and data pre-processing.

@manumerous Any thoughts on this?