### PR TITLE
Updated README

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,29 +71,15 @@ source setup.bash
 Generate the parametric model using a log file (ulog or csv):
 
 ```
-python3 Tools/parametric_model/generate_parametric_model --model <model> --data_selection <True/False> log_file
-```
-
-Or more simply using the make command:
-
-```
 make estimate-model [model=<modeltype>] [config=<config_file_path>] [data_selection=<True/False>] log=<log_file_path>
 ```
 
-### Running different Models
-Hereby the arguments model and log_file can be used to specify the model and the log files respectively. The data_selection argument is optional (per default False) and can be used to visually select a subportion of the data before running the model estimation.
+### Pipeline Arguments
 
-As an example you could use the reference log_files:
+#### Model Choice
 
-```
-make estimate-model model=quad_plane_model log=resources/simple_quadplane_model.ulg
-```
-
-```
-make estimate-model model=quad_plane_model log=resources/simple_quadplane_model.csv
-```
-
-Current model choices are:
+The chosen vehicle model class determines what physical effects are modelled and what parameterts need to be regressed in the system identification process.
+Current vehicle model choices are:
 
 - quadrotor_model
 
@@ -103,9 +89,29 @@ Current model choices are:
 
 - tilt_wing_model
 
-The results of the model estimation will be saved into the Tools/parametric_model/results folder as a yaml file.
+#### Config File
 
-The pipeline / models can be configured through a configuration file. The default location is in `Tools/parametric_model/configs`. The path can be passed in the make target through the `config=<config_file_path>` argument.
+The config file allows to configure the intra class vehicle variations, used log file topics, data processing and other aspects of the pipeline. The default location is in `Tools/parametric_model/configs`. The path can be passed in the make target through the `config=<config_file_path>` argument. If no config is specified the default model config is used.
+
+#### Log File
+
+The Log file contains all data needed for the system identification of the specified model as defined in its config file. Next to the [ULog](https://docs.px4.io/master/en/dev_log/ulog_file_format.html) file format it is also possible to provide the data as a csv file. An example of the required formating can be seen in the `resources` folder.
+
+#### Data Selection
+
+The data_selection argument is optional (per default False) and can be used to visually select subportions of the data, using the [Visual Dataframe Selector](https://github.com/manumerous/visual_dataframe_selector), before running the model estimation. It is also possible to save the selected subportion of data to a csv file in order to use this exact dataset multiple times.
+
+### Results
+
+The resulting parameters of the model estimation together with additional report information will be saved into the `model_results` folder as a yaml file.
+
+### Getting Started
+
+As an example to get started you estimate the parameters of a quadrotor model with the reference log_files:
+
+```
+make estimate-model model=quadrotor_model log=resources/quadrotor_model.ulg
+```
 
 ## Testing the functionality of Parametric model
 


### PR DESCRIPTION
This commit removes the instructions to run the pipeline directly with python. I think specifying and supporting multiple versions of running the program is potentially just confusing for new operators while providing minimal additional value. 

Furthermore, The commit extended on the documentation of the different arguments of the `estimate-model` command. 