### PR TITLE
Enable moment estimation for quadrotor_model

### DIFF
--- a/Tools/parametric_model/configs/quadrotor_model.yaml
+++ b/Tools/parametric_model/configs/quadrotor_model.yaml
@@ -12,6 +12,7 @@ model_config:
       vertical_:
         - rotor_0:
           description: "front right rotor"
+          rotor_type: "RotorModel"
           dataframe_name: "u0"
           rotor_axis:
             - 0
@@ -25,6 +26,7 @@ model_config:
 
         - rotor_1:
           description: "back left rotor"
+          rotor_type: "RotorModel"
           dataframe_name: "u1"
           rotor_axis:
             - 0
@@ -38,6 +40,7 @@ model_config:
 
         - rotor_2:
           description: "front left rotor"
+          rotor_type: "RotorModel"
           dataframe_name: "u2"
           rotor_axis:
             - 0
@@ -51,6 +54,7 @@ model_config:
 
         - rotor_3:
           description: "back right rotor"
+          rotor_type: "RotorModel"
           dataframe_name: "u3"
           rotor_axis:
             - 0
@@ -64,7 +68,7 @@ model_config:
 
 dynamics_model_config:
   estimate_forces: True
-  estimate_moments: False
+  estimate_moments: True
   resample_freq: 100.0
   data:
     required_ulog_topics:

--- a/Tools/parametric_model/src/models/multirotor_model.py
+++ b/Tools/parametric_model/src/models/multirotor_model.py
@@ -43,9 +43,6 @@ class MultiRotorModel(DynamicsModel):
 
         self.model_name = model_name
 
-        assert (self.estimate_moments ==
-                False), "Estimation of moments is not yet implemented in DeltaQuadPlaneModel. Disable in config file to estimate forces."
-
     def prepare_regression_matrices(self):
 
         if "V_air_body_x" not in self.data_df:


### PR DESCRIPTION
**Problem Description**
Moment estimation has been disabled on the quadrotor_model. This PR enables moment estimation by default on the quadrotor_model, and fixes the issues that occured when trying to enable moment estimation.
- Enabled moment estimation by default for `quadrotor_model`
- Specified rotor type as pipeline was complaining no rotor type
- Removed failure assertion when moment estimation was enabled

**Additional Context**
- Attempt to fix https://github.com/ethz-asl/data-driven-dynamics/issues/101 and fix https://github.com/ethz-asl/data-driven-dynamics/issues/99