### PR TITLE
Add mass for multirotor model config

### DIFF
--- a/Tools/parametric_model/configs/quadrotor_model.yaml
+++ b/Tools/parametric_model/configs/quadrotor_model.yaml
@@ -7,6 +7,7 @@ model_file:
 
   # all vectors in FRD body frame if not specified otherwise
 model_config:
+  mass: 1.5
   actuators:
     rotors:
       vertical_:

--- a/Tools/parametric_model/src/models/multirotor_model.py
+++ b/Tools/parametric_model/src/models/multirotor_model.py
@@ -40,6 +40,7 @@ class MultiRotorModel(DynamicsModel):
         self.config = ModelConfig(config_file)
         super(MultiRotorModel, self).__init__(
             config_dict=self.config.dynamics_model_config)
+        self.mass = self.config.model_config["mass"]
         self.rotor_config_dict = self.config.model_config["actuators"]["rotors"]
 
         self.model_name = model_name
@@ -81,7 +82,7 @@ class MultiRotorModel(DynamicsModel):
 
         accel_mat = self.data_df[[
             "acc_b_x", "acc_b_y", "acc_b_z"]].to_numpy()
-        self.y_forces = (accel_mat).flatten()
+        self.y_forces = (accel_mat).flatten() * self.mass
 
         aoa_mat = self.data_df[["AoA"]].to_numpy()
         airspeed_mat = self.data_df[["V_air_body_x",


### PR DESCRIPTION
**Problem Description**
The `multirotor_model` was not considering the mass of the vehicle and assuming that the acceleration is equal to the force. Therefore, the coefficients were only valid when the mass of the vehicle was 1kg

This commit adds mass to the multirotor model config and consumes for the multirotor dynamics model

**Before PR**
With input aerodynamic velocity
![Figure_1](https://user-images.githubusercontent.com/5248102/126059110-bc12ef9d-f935-4e21-bc86-01ec0a35049b.png)
With zero aerodynamic velocity
![Figure_2](https://user-images.githubusercontent.com/5248102/126059788-b066cb50-c56d-4ebb-9d28-cc5e63fb0d8d.png)

**After PR**
With input aerodynamic velocity
![Rotor_Feature_Computation](https://user-images.githubusercontent.com/5248102/126065767-cec0fca6-98b9-4b0a-a704-43cba6af9caf.png)
With zero aerodynamic velocity
![Figure_2](https://user-images.githubusercontent.com/5248102/126065769-518e2304-3c2d-4e47-bd75-d92367436603.png)


**Additional Context**
- This problem was found when trying to fly the `iris` with the identified parameters in https://github.com/ethz-asl/data-driven-dynamics/pull/89, which is 1.5kg heavy.