### PR TITLE
Enforce function naming from baseclass

### DIFF
--- a/Tools/parametric_model/src/models/dynamics_model.py
+++ b/Tools/parametric_model/src/models/dynamics_model.py
@@ -44,6 +44,9 @@ class DynamicsModel():
         self.coef_name_list = []
         self.result_dict = {}
 
+    def prepare_regression_matrices(self):
+        raise NotImplementedError()
+
     def get_topic_list_from_topic_type(self, topic_type):
         topic_type_name_dict = self.req_topics_dict[topic_type]
         if "dataframe_name" in topic_type_name_dict.keys():

--- a/Tools/parametric_model/src/models/tiltwing_model.py
+++ b/Tools/parametric_model/src/models/tiltwing_model.py
@@ -53,7 +53,7 @@ class TiltWingModel(DynamicsModel):
         assert (self.estimate_moments ==
                 False), "Estimation of moments is not yet implemented in TiltWingModel. Disable in config file to estimate forces."
 
-    def prepare_opimization_matrices(self):
+    def prepare_regression_matrices(self):
 
         airspeed_mat = self.data_df[["V_air_body_x",
                                      "V_air_body_y", "V_air_body_z"]].to_numpy()
@@ -123,7 +123,7 @@ class TiltWingModel(DynamicsModel):
         print(self.data_df.columns)
         self.data_df_len = self.data_df.shape[0]
         print("resampled data contains ", self.data_df_len, "timestamps.")
-        self.prepare_opimization_matrices()
+        self.prepare_regression_matrices()
 
         # optimization_variables:
         optimization_parameters = self.config.model_config["optimzation_parameters"]


### PR DESCRIPTION
**Problem Description**
There was a discrepancy of method naming of the tiltwing model compared to other models.


**Proposed Solution**
This commit enforces that prepare_regression_matrices are implemented in children classes of dynamics_model class by raising a `notImplemented` exception if the method doesn't exist. This is trying to enforce a `virtual` function as in cpp