### PR TITLE
Fix build status badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # data-driven-dynamics
 
-[![Build Tests](https://github.com/Jaeyoung-Lim/data-driven-dynamics/actions/workflows/build_test.yml/badge.svg)](https://github.com/Jaeyoung-Lim/data-driven-dynamics/actions/workflows/build_test.yml)
+[![Build Tests](https://github.com/ethz-asl/data-driven-dynamics/actions/workflows/build_test.yml/badge.svg)](https://github.com/ethz-asl/data-driven-dynamics/actions/workflows/build_test.yml)
 
 This repository allows a data-driven dynamics model for PX4 SITL(Software-In-The-Loop) simulations.
 


### PR DESCRIPTION
For some reason, the build status badge was pointing to my fork.