### PR TITLE
Parse multiple logs from directory

### DIFF
--- a/Tools/parametric_model/generate_parametric_model.py
+++ b/Tools/parametric_model/generate_parametric_model.py
@@ -30,7 +30,7 @@ def start_model_estimation(arg_list):
     config_file = arg_list.config
 
     data_handler = DataHandler(config_file)
-    data_handler.loadLog(arg_list.log_path)
+    data_handler.loadLogs(arg_list.log_path)
     if data_selection_enabled:
         data_handler.visually_select_data()
     data_handler.visualize_data()

--- a/Tools/parametric_model/src/tools/data_handler.py
+++ b/Tools/parametric_model/src/tools/data_handler.py
@@ -47,40 +47,36 @@ class DataHandler(object):
         self.coef_name_list = []
         self.result_dict = {}
 
-    def loadLog(self, rel_data_path):
+    def loadLogs(self, rel_data_path):
         self.rel_data_path = rel_data_path
         if (os.path.isdir(rel_data_path)):
             self.data_df = pd.DataFrame()
             for filename in os.listdir(rel_data_path):
-                if filename.endswith(".ulg"):
-                    print(os.path.join(rel_data_path, filename))
-                    ulog = load_ulog(os.path.join(rel_data_path, filename))
-                    self.check_ulog_for_req_topics(ulog)
-                    self.data_df = self.data_df.append(self.compute_resampled_dataframe(ulog))
-                    self.data_df.reset_index(drop=True, inplace=True)
-
-                elif filename.endswith(".csv"):
-                    raise Exception("Parsing CSV files from a directory is not supported")
-                    
-                else:
-                    continue
+                self.loadLogFile(os.path.join(rel_data_path, filename))
 
         else:
-            if (rel_data_path.endswith(".csv")):
-                self.data_df = pd.read_csv(rel_data_path, index_col=0)
-                for req_topic in self.req_dataframe_topic_list:
-                    assert(
-                        req_topic in self.data_df), ("missing topic in loaded csv: " + str(req_topic))
-
-            elif (rel_data_path.endswith(".ulg")):
-                ulog = load_ulog(rel_data_path)
-                self.check_ulog_for_req_topics(ulog)
-
-                self.data_df = self.compute_resampled_dataframe(ulog)
-
-            else:
+            if not self.loadLogFile(rel_data_path):
                 raise TypeError("File extension needs to be either csv or ulg")
 
+    def loadLogFile(self, rel_data_path):
+        if (rel_data_path.endswith(".csv")):
+            self.data_df = pd.read_csv(rel_data_path, index_col=0)
+            for req_topic in self.req_dataframe_topic_list:
+                assert(
+                    req_topic in self.data_df), ("missing topic in loaded csv: " + str(req_topic))
+            
+            return True
+
+        elif (rel_data_path.endswith(".ulg")):
+            ulog = load_ulog(rel_data_path)
+            self.check_ulog_for_req_topics(ulog)
+
+            self.data_df = self.compute_resampled_dataframe(ulog)
+
+            return True
+
+        else:
+            return False
 
     def check_ulog_for_req_topics(self, ulog):
         for topic_type in self.req_topics_dict.keys():

--- a/Tools/parametric_model/tests/test_dynamics_model.py
+++ b/Tools/parametric_model/tests/test_dynamics_model.py
@@ -19,7 +19,7 @@ def test_transformations(config_file="dynamics_model_test_config.yaml"):
     config = ModelConfig(config_file_path)
 
     data_handler = DataHandler(config_file_path)
-    data_handler.loadLog("resources/quadrotor_model.ulg")
+    data_handler.loadLogs("resources/quadrotor_model.ulg")
 
     data_df = data_handler.get_dataframes()
 


### PR DESCRIPTION
**Problem Description**
This repository is structured so that it learns the dynamics of the vehicle from a "single" flight log. Therefore, current pipeline assumes that there is only one `ulog` file and stores it in `data_handler.ulog`.

However, it is challenging to acquire all information from a single flight and flight-specific configurations might make the learned dynamics less general. This also limits using methods that require more data, such as neural network based methods.

A better solution would be learning from data frames loaded from various flights. 

**Proposed Solution**
This commit allows the pipeline to parse data frames from multiple flight logs from a directory. When passed a directory path to the pipeline, the data handler iterates along the files that are inside the directory.

For example, the following can be used for a single flight log
```
make estimate-model model=<model_type> log=<file_name>.ulg
```
and to iterate through the directory
```
make estimate-model model=<model_type> log=<directory_path>
```


**Additional Context**
- This feature only iterates over ulog files and will throw an exception if there are csv files in the directory. 
- Fixes https://github.com/ethz-asl/data-driven-dynamics/issues/122