### PR TITLE
Define and parse vehicle inertia properties for standardplane model

### DIFF
--- a/Tools/parametric_model/configs/standardplane_model.yaml
+++ b/Tools/parametric_model/configs/standardplane_model.yaml
@@ -6,6 +6,11 @@ model_class:
 
   # all vectors in FRD body frame if not specified otherwise
 model_config:
+  mass: 1.5
+  moment_of_inertia:
+    Ixx: 0.197563
+    Iyy: 0.1458929
+    Izz: 0.1477
   actuators:
     rotors:
       # All rotors in the same group will share the coefficients


### PR DESCRIPTION
**Problem Description**
This commit defines and parses inertia related properties for the `standardplane_model`

The inertial properties are from the simulated fixedwing vehicle: 

https://github.com/PX4/PX4-SITL_gazebo/blob/7fda4d311a9daff4bec4f2fe83e63fde0b8f04b0/models/plane/plane.sdf.jinja#L7-L18

**Additional Context**
- This PR includes #128 
- This PR addresses https://github.com/ethz-asl/data-driven-dynamics/issues/109
