### PR TITLE
Move plotting to dynamics model parent class

### DIFF
--- a/Tools/parametric_model/src/models/dynamics_model.py
+++ b/Tools/parametric_model/src/models/dynamics_model.py
@@ -13,8 +13,10 @@ import yaml
 import numpy as np
 from sklearn.linear_model import LinearRegression
 from scipy.linalg import block_diag
+import matplotlib.pyplot as plt
 
 from .rotor_models import RotorModel, BiDirectionalRotorModel, TiltingRotorModel, ChangingAxisRotorModel
+from .model_plots import model_plots
 from src.tools.ulog_tools import load_ulog, pandas_from_topic
 from src.tools.dataframe_tools import compute_flight_time, resample_dataframe_list
 from src.tools.quat_utils import quaternion_to_rotation_matrix
@@ -366,3 +368,56 @@ class DynamicsModel():
             "residual_moment_x", "residual_moment_y", "residual_moment_z"])
         self.data_df = pd.concat(
             [self.data_df, residual_moment_df], axis=1, join="inner")
+
+    def plot_model_predicitons(self):
+        def plot_scatter(ax, title, dataframe_x, dataframe_y, dataframe_z, color='blue'):
+            ax.scatter(self.data_df[dataframe_x], self.data_df[dataframe_y], self.data_df[dataframe_z], s=10, facecolor=color, lw=0, alpha=0.1)
+            ax.set_title(title)
+            ax.set_xlabel(dataframe_x)
+            ax.set_ylabel(dataframe_y)
+            ax.set_zlabel(dataframe_z)
+
+        y_pred = self.reg.predict(self.X)
+
+        if (self.estimate_forces and self.estimate_moments):
+            y_forces_pred = y_pred[0:self.y_forces.shape[0]]
+            y_moments_pred = y_pred[self.y_forces.shape[0]:]
+            model_plots.plot_accel_predeictions(
+                self.y_forces, y_forces_pred, self.data_df["timestamp"])
+            model_plots.plot_angular_accel_predeictions(
+                self.y_moments, y_moments_pred, self.data_df["timestamp"])
+            model_plots.plot_airspeed_and_AoA(
+                self.data_df[["V_air_body_x", "V_air_body_y", "V_air_body_z", "AoA"]], self.data_df["timestamp"])
+
+        elif (self.estimate_forces):
+            y_forces_pred = y_pred
+            model_plots.plot_accel_predeictions(
+                self.y_forces, y_forces_pred, self.data_df["timestamp"])
+            model_plots.plot_airspeed_and_AoA(
+                self.data_df[["V_air_body_x", "V_air_body_y", "V_air_body_z", "AoA"]], self.data_df["timestamp"])
+
+        elif (self.estimate_moments):
+            y_moments_pred = y_pred
+            model_plots.plot_angular_accel_predeictions(
+                self.y_moments, y_moments_pred, self.data_df["timestamp"])
+            model_plots.plot_airspeed_and_AoA(
+                self.data_df[["V_air_body_x", "V_air_body_y", "V_air_body_z", "AoA"]], self.data_df["timestamp"])
+
+        fig = plt.figure("Residual Visualization")
+        ax1 = fig.add_subplot(2, 2, 1, projection='3d')
+        plot_scatter(ax1, "Residual force", "residual_force_x", "residual_force_y", "residual_force_z", 'blue')
+
+        ax2 = fig.add_subplot(2, 2, 2, projection='3d')
+
+        plot_scatter(ax2, "Residual moment", "residual_moment_x", "residual_moment_y", "residual_moment_z", 'blue')
+
+        ax3 = fig.add_subplot(2, 2, 3, projection='3d')
+
+        plot_scatter(ax3, "Measured Force", "acc_b_x", "acc_b_y", "acc_b_z", 'blue')
+
+        ax4 = fig.add_subplot(2, 2, 4, projection='3d')
+
+        plot_scatter(ax4, "Measured Moment", "ang_acc_b_x", "ang_acc_b_y", "ang_acc_b_z", 'blue')
+
+        plt.show()
+        return

--- a/Tools/parametric_model/src/models/multirotor_model.py
+++ b/Tools/parametric_model/src/models/multirotor_model.py
@@ -28,10 +28,8 @@ import math
 from sklearn.linear_model import LinearRegression
 from .dynamics_model import DynamicsModel
 from .rotor_models import RotorModel
-from .model_plots import model_plots
 from .aerodynamic_models import FuselageDragModel
 from .model_config import ModelConfig
-import matplotlib.pyplot as plt
 
 
 class MultiRotorModel(DynamicsModel):
@@ -68,56 +66,3 @@ class MultiRotorModel(DynamicsModel):
         self.y_moments = moment_mat.flatten()
         self.X_moments = self.X_rotor_moments
         self.coef_name_list.extend(self.rotor_moments_coef_list)
-
-    def plot_model_predicitons(self):
-        def plot_scatter(ax, title, dataframe_x, dataframe_y, dataframe_z, color='blue'):
-            ax.scatter(self.data_df[dataframe_x], self.data_df[dataframe_y], self.data_df[dataframe_z], s=10, facecolor=color, lw=0, alpha=0.1)
-            ax.set_title(title)
-            ax.set_xlabel(dataframe_x)
-            ax.set_ylabel(dataframe_y)
-            ax.set_zlabel(dataframe_z)
-
-        y_pred = self.reg.predict(self.X)
-
-        if (self.estimate_forces and self.estimate_moments):
-            y_forces_pred = y_pred[0:self.y_forces.shape[0]]
-            y_moments_pred = y_pred[self.y_forces.shape[0]:]
-            model_plots.plot_accel_predeictions(
-                self.y_forces, y_forces_pred, self.data_df["timestamp"])
-            model_plots.plot_angular_accel_predeictions(
-                self.y_moments, y_moments_pred, self.data_df["timestamp"])
-            model_plots.plot_airspeed_and_AoA(
-                self.data_df[["V_air_body_x", "V_air_body_y", "V_air_body_z", "AoA"]], self.data_df["timestamp"])
-
-        elif (self.estimate_forces):
-            y_forces_pred = y_pred
-            model_plots.plot_accel_predeictions(
-                self.y_forces, y_forces_pred, self.data_df["timestamp"])
-            model_plots.plot_airspeed_and_AoA(
-                self.data_df[["V_air_body_x", "V_air_body_y", "V_air_body_z", "AoA"]], self.data_df["timestamp"])
-
-        elif (self.estimate_moments):
-            y_moments_pred = y_pred
-            model_plots.plot_angular_accel_predeictions(
-                self.y_moments, y_moments_pred, self.data_df["timestamp"])
-            model_plots.plot_airspeed_and_AoA(
-                self.data_df[["V_air_body_x", "V_air_body_y", "V_air_body_z", "AoA"]], self.data_df["timestamp"])
-
-        fig = plt.figure("Residual Visualization")
-        ax1 = fig.add_subplot(2, 2, 1, projection='3d')
-        plot_scatter(ax1, "Residual force", "residual_force_x", "residual_force_y", "residual_force_z", 'blue')
-
-        ax2 = fig.add_subplot(2, 2, 2, projection='3d')
-
-        plot_scatter(ax2, "Residual moment", "residual_moment_x", "residual_moment_y", "residual_moment_z", 'blue')
-
-        ax3 = fig.add_subplot(2, 2, 3, projection='3d')
-
-        plot_scatter(ax3, "Measured Force", "acc_b_x", "acc_b_y", "acc_b_z", 'blue')
-
-        ax4 = fig.add_subplot(2, 2, 4, projection='3d')
-
-        plot_scatter(ax4, "Measured Moment", "ang_acc_b_x", "ang_acc_b_y", "ang_acc_b_z", 'blue')
-
-        plt.show()
-        return

--- a/Tools/parametric_model/src/models/quadplane_model.py
+++ b/Tools/parametric_model/src/models/quadplane_model.py
@@ -13,10 +13,8 @@ from .dynamics_model import DynamicsModel
 from .rotor_models import RotorModel
 from sklearn.linear_model import LinearRegression
 from scipy.linalg import block_diag
-from .model_plots import model_plots, quad_plane_model_plots
 from .model_config import ModelConfig
 from .aerodynamic_models import StandardWingModel, ControlSurfaceModel
-import matplotlib.pyplot as plt
 
 
 """This model estimates forces and moments for quad plane as for example the standard vtol in gazebo."""
@@ -110,35 +108,3 @@ class QuadPlaneModel(DynamicsModel):
             # Set coefficients
             self.coef_name_list.extend(
                 self.rotor_moments_coef_list + X_body_rot_moment_coef_list)
-
-    def plot_model_predicitons(self):
-
-        y_pred = self.reg.predict(self.X)
-
-        if (self.estimate_forces and self.estimate_moments):
-            y_forces_pred = y_pred[0:self.y_forces.shape[0]]
-            y_moments_pred = y_pred[self.y_forces.shape[0]:]
-            model_plots.plot_accel_predeictions(
-                self.y_forces, y_forces_pred, self.data_df["timestamp"])
-            model_plots.plot_angular_accel_predeictions(
-                self.y_moments, y_moments_pred, self.data_df["timestamp"])
-            model_plots.plot_airspeed_and_AoA(
-                self.data_df[["V_air_body_x", "V_air_body_y", "V_air_body_z", "AoA"]], self.data_df["timestamp"])
-
-        elif (self.estimate_forces):
-            y_forces_pred = y_pred
-            model_plots.plot_accel_predeictions(
-                self.y_forces, y_forces_pred, self.data_df["timestamp"])
-            model_plots.plot_airspeed_and_AoA(
-                self.data_df[["V_air_body_x", "V_air_body_y", "V_air_body_z", "AoA"]], self.data_df["timestamp"])
-
-        elif (self.estimate_moments):
-            y_moments_pred = y_pred
-            model_plots.plot_angular_accel_predeictions(
-                self.y_moments, y_moments_pred, self.data_df["timestamp"])
-            model_plots.plot_airspeed_and_AoA(
-                self.data_df[["V_air_body_x", "V_air_body_y", "V_air_body_z", "AoA"]], self.data_df["timestamp"])
-
-        plt.show()
-
-        return

--- a/Tools/parametric_model/src/models/standardplane_model.py
+++ b/Tools/parametric_model/src/models/standardplane_model.py
@@ -12,10 +12,8 @@ import math
 from .dynamics_model import DynamicsModel
 from .rotor_models import RotorModel
 from sklearn.linear_model import LinearRegression
-from .model_plots import model_plots, quad_plane_model_plots
 from .model_config import ModelConfig
 from .aerodynamic_models import StandardWingModel, ControlSurfaceModel
-import matplotlib.pyplot as plt
 
 
 """This model estimates forces and moments for quad plane as for example the standard vtol in gazebo."""
@@ -105,35 +103,3 @@ class StandardPlaneModel(DynamicsModel):
             # Set coefficients
             self.coef_name_list.extend(
                 self.rotor_moments_coef_list + X_body_rot_moment_coef_list)
-
-    def plot_model_predicitons(self):
-
-        y_pred = self.reg.predict(self.X)
-
-        if (self.estimate_forces and self.estimate_moments):
-            y_forces_pred = y_pred[0:self.y_forces.shape[0]]
-            y_moments_pred = y_pred[self.y_forces.shape[0]:]
-            model_plots.plot_accel_predeictions(
-                self.y_forces, y_forces_pred, self.data_df["timestamp"])
-            model_plots.plot_angular_accel_predeictions(
-                self.y_moments, y_moments_pred, self.data_df["timestamp"])
-            model_plots.plot_airspeed_and_AoA(
-                self.data_df[["V_air_body_x", "V_air_body_y", "V_air_body_z", "AoA"]], self.data_df["timestamp"])
-
-        elif (self.estimate_forces):
-            y_forces_pred = y_pred
-            model_plots.plot_accel_predeictions(
-                self.y_forces, y_forces_pred, self.data_df["timestamp"])
-            model_plots.plot_airspeed_and_AoA(
-                self.data_df[["V_air_body_x", "V_air_body_y", "V_air_body_z", "AoA"]], self.data_df["timestamp"])
-
-        elif (self.estimate_moments):
-            y_moments_pred = y_pred
-            model_plots.plot_angular_accel_predeictions(
-                self.y_moments, y_moments_pred, self.data_df["timestamp"])
-            model_plots.plot_airspeed_and_AoA(
-                self.data_df[["V_air_body_x", "V_air_body_y", "V_air_body_z", "AoA"]], self.data_df["timestamp"])
-
-        plt.show()
-
-        return


### PR DESCRIPTION
**Problem Description**
The plotting tools were part of the dynamics model, therefore each model had different plots.

**Proposed Solution**
This commit moves plotting to the dynamics model parent class so that we can have consistent plotting for all models. In case a model needs a model specific plot, the same method can be overridden with the child class implementation