### PR TITLE
Fix stall angle conversion

### DIFF
--- a/Tools/parametric_model/configs/quadplane_model.yaml
+++ b/Tools/parametric_model/configs/quadplane_model.yaml
@@ -94,6 +94,7 @@ model_config:
           dataframe_name: "u7"
 
   aerodynamics:
+    area: 1.2
     stall_angle_deg: 20
     sig_scale_factor: 30
 

--- a/Tools/parametric_model/configs/standardplane_model.yaml
+++ b/Tools/parametric_model/configs/standardplane_model.yaml
@@ -52,6 +52,7 @@ model_config:
           dataframe_name: "u3"
 
   aerodynamics:
+    area: 1.2
     stall_angle_deg: 20
     sig_scale_factor: 30
 

--- a/Tools/parametric_model/src/models/aerodynamic_models/standard_wing_model.py
+++ b/Tools/parametric_model/src/models/aerodynamic_models/standard_wing_model.py
@@ -18,11 +18,11 @@ https://docs.px4.io/master/en/airframes/airframe_reference.html#standard-plane
 
 
 class StandardWingModel():
-    def __init__(self, config_dict, stall_angle=35.0, sig_scale_fac=30):
-        self.stall_angle = stall_angle*math.pi/180.0
-        self.sig_scale_fac = sig_scale_fac
+    def __init__(self, config_dict):
+        self.stall_angle = config_dict["stall_angle_deg"]*math.pi/180.0
+        self.sig_scale_fac = config_dict["sig_scale_factor"]
         self.air_density = 1.225
-        self.area = 1.2 # [m^2]
+        self.area = config_dict["area"]
 
     def compute_wing_force_features(self, v_airspeed, angle_of_attack):
         """
@@ -52,8 +52,9 @@ class StandardWingModel():
 
         # region interpolation using a symmetric sigmoid function
         # 0 in linear/quadratic region, 1 in post-stall region
+
         stall_region = cropped_sym_sigmoid(
-            np.abs(angle_of_attack), x_offset=self.stall_angle, scale_fac=self.sig_scale_fac)
+            angle_of_attack, x_offset=self.stall_angle, scale_fac=self.sig_scale_fac)
         # 1 in linear/quadratic region, 0 in post-stall region
         flow_attached_region = 1 - stall_region
 

--- a/Tools/parametric_model/src/models/quadplane_model.py
+++ b/Tools/parametric_model/src/models/quadplane_model.py
@@ -33,18 +33,14 @@ class QuadPlaneModel(DynamicsModel):
 
         self.rotor_config_dict = self.config.model_config["actuators"]["rotors"]
         self.aero_config_dict = self.config.model_config["actuators"]["control_surfaces"]
-
-        self.stall_angle = math.pi/180 * \
-            self.config.model_config["aerodynamics"]["stall_angle_deg"]
-        self.sig_scale_fac = self.config.model_config["aerodynamics"]["sig_scale_factor"]
+        self.aerodynamics_dict = self.config.model_config["aerodynamics"]
 
     def prepare_force_regression_matrices(self):
             # Aerodynamics features
             airspeed_mat = self.data_df[[
                 "V_air_body_x", "V_air_body_y", "V_air_body_z"]].to_numpy()
             aoa_mat = self.data_df[["AoA"]].to_numpy()
-            aero_model = StandardWingModel(self.aero_config_dict,
-                stall_angle=self.stall_angle, sig_scale_fac=self.sig_scale_fac)
+            aero_model = StandardWingModel(self.aerodynamics_dict)
             X_aero_forces, aero_coef_list = aero_model.compute_aero_features(airspeed_mat, aoa_mat)
 
             self.aero_forces_coef_list = aero_coef_list
@@ -60,8 +56,7 @@ class QuadPlaneModel(DynamicsModel):
                 for config_dict in aero_group_list:
                     controlsurface_input_name = config_dict["dataframe_name"]
                     u_vec = self.data_df[controlsurface_input_name].to_numpy()
-                    control_surface_model = ControlSurfaceModel(config_dict, u_vec, stall_angle=self.stall_angle, 
-                        sig_scale_fac=self.sig_scale_fac)
+                    control_surface_model = ControlSurfaceModel(config_dict, self.aerodynamics_dict, u_vec)
 
                     if (self.estimate_forces):
                         X_force_curr, curr_aero_forces_coef_list = control_surface_model.compute_actuator_force_matrix(airspeed_mat, aoa_mat)


### PR DESCRIPTION
**Problem Description**
Stall angles were converted from degrees to radians twice.

**Proposed Solution**
Properly convert degrees to radians. To prevent this from happening again, I have refactored how the aerodynamic coefficients are being parsed from the config file.

**Additional Context**
While this is more "correct", this breaks the standard plane model
**Standard Plane Model**
![Figure_6](https://user-images.githubusercontent.com/5248102/128845402-8984e946-e761-495e-baaa-390b80dafb39.png)

I am assuming that the issue was just hidden, since the angle of attack range that were observed are very small
![Figure_4](https://user-images.githubusercontent.com/5248102/128845406-63c94e13-34c6-4683-a6e6-d37307b1d4d8.png)


**Quadplane Model**
With the standard VTOL, this looks much better
![Figure_6](https://user-images.githubusercontent.com/5248102/128846677-f926a0c8-4d39-46a2-af1f-95e866549de3.png)
![Figure_4](https://user-images.githubusercontent.com/5248102/128846672-67f30a5f-e2f5-404c-8d63-cec617142dda.png)
