### PR TITLE
Add moment coefficients for the standard wing model and control surfaces

### DIFF
--- a/Tools/parametric_model/src/models/dynamics_model.py
+++ b/Tools/parametric_model/src/models/dynamics_model.py
@@ -413,11 +413,11 @@ class DynamicsModel():
 
         ax3 = fig.add_subplot(2, 2, 3, projection='3d')
 
-        plot_scatter(ax3, "Measured Force", "acc_b_x", "acc_b_y", "acc_b_z", 'blue')
+        plot_scatter(ax3, "Measured Acceleration", "acc_b_x", "acc_b_y", "acc_b_z", 'blue')
 
         ax4 = fig.add_subplot(2, 2, 4, projection='3d')
 
-        plot_scatter(ax4, "Measured Moment", "ang_acc_b_x", "ang_acc_b_y", "ang_acc_b_z", 'blue')
+        plot_scatter(ax4, "Measured Angular Acceleration", "ang_acc_b_x", "ang_acc_b_y", "ang_acc_b_z", 'blue')
 
         plt.show()
         return

--- a/Tools/parametric_model/src/models/quadplane_model.py
+++ b/Tools/parametric_model/src/models/quadplane_model.py
@@ -41,7 +41,9 @@ class QuadPlaneModel(DynamicsModel):
                 "V_air_body_x", "V_air_body_y", "V_air_body_z"]].to_numpy()
             aoa_mat = self.data_df[["AoA"]].to_numpy()
             aero_model = StandardWingModel(self.aerodynamics_dict)
-            X_aero_forces, aero_coef_list = aero_model.compute_aero_features(airspeed_mat, aoa_mat)
+            X_aero_forces, aero_coef_list = aero_model.compute_aero_force_features(airspeed_mat, aoa_mat)
+            aero_model = StandardWingModel(self.aerodynamics_dict)
+            X_aero_forces, aero_coef_list = aero_model.compute_aero_force_features(airspeed_mat, aoa_mat)
 
             self.aero_forces_coef_list = aero_coef_list
             self.X_aero_forces = X_aero_forces
@@ -87,19 +89,48 @@ class QuadPlaneModel(DynamicsModel):
                 self.rotor_forces_coef_list + self.aero_forces_coef_list)
 
     def prepare_moment_regression_matrices(self):
-            # features due to rotation of body frame
-            X_body_rot_moment, X_body_rot_moment_coef_list = self.compute_body_rotation_features(
-                ["ang_vel_x", "ang_vel_y", "ang_vel_z"])
-            self.X_moments = np.hstack(
-                (self.X_rotor_moments, X_body_rot_moment))
-            self.X = self.X_moments
+            # Aerodynamics features
+            airspeed_mat = self.data_df[[
+                "V_air_body_x", "V_air_body_y", "V_air_body_z"]].to_numpy()
+            aoa_mat = self.data_df[["AoA"]].to_numpy()
+            aero_model = StandardWingModel(self.aerodynamics_dict)
+            X_aero_moments, aero_moments_coef_list = aero_model.compute_aero_moment_features(airspeed_mat, aoa_mat)
+
+            self.aero_moments_coef_list = aero_moments_coef_list
+            self.X_aero_moments = X_aero_moments
+
+            aero_config_dict = self.aero_config_dict
+            for aero_group in aero_config_dict.keys():
+                aero_group_list = self.aero_config_dict[aero_group]
+
+                for config_dict in aero_group_list:
+                    controlsurface_input_name = config_dict["dataframe_name"]
+                    u_vec = self.data_df[controlsurface_input_name].to_numpy()
+                    control_surface_model = ControlSurfaceModel(config_dict, self.aerodynamics_dict, u_vec)
+
+                    if (self.estimate_moments):
+                        X_moment_curr, curr_aero_moments_coef_list = control_surface_model.compute_actuator_moment_matrix(airspeed_mat, aoa_mat)
+                        # Include aero group name in coefficient names:
+                        for i in range(len(curr_aero_moments_coef_list)):
+                            curr_aero_moments_coef_list[i] = list(config_dict.keys())[0] + "_" + \
+                                curr_aero_moments_coef_list[i]
+                
+                        if 'X_aero_moments' not in vars():
+                            X_aero_moments = X_moment_curr
+                            self.aero_moments_coef_list = curr_aero_moments_coef_list
+                        else:
+                            X_aero_moments = np.hstack(
+                                (X_aero_moments, X_moment_curr))
+                            self.aero_moments_coef_list += curr_aero_moments_coef_list
+                        self.X_aero_moments = X_aero_moments
+
+            self.X_moments = np.hstack((self.X_rotor_moments, self.X_aero_moments))
 
             # Angular acceleration
-            angular_accel_body_mat = self.data_df[[
-                "ang_acc_b_x", "ang_acc_b_y", "ang_acc_b_z"]].to_numpy()
-            self.y_moments = angular_accel_body_mat.flatten()
-            self.y = self.y_moments
+            moment_mat = np.matmul(self.data_df[[
+                "ang_acc_b_x", "ang_acc_b_y", "ang_acc_b_z"]].to_numpy(), self.moment_of_inertia)
+            self.y_moments = moment_mat.flatten()
 
             # Set coefficients
             self.coef_name_list.extend(
-                self.rotor_moments_coef_list + X_body_rot_moment_coef_list)
+                self.rotor_moments_coef_list + self.aero_moments_coef_list)


### PR DESCRIPTION
**Problem Description**
This commit adds moment coefficients for the standard wing model and control surfaces

**Testing**
This was tested with a `quadplane_model` with a custom flight log generated in manual and stabilized mode

```
make estimate-model model=quadplane_model log=resources/<custom_log>
```

![quadplane2](https://user-images.githubusercontent.com/5248102/128892975-a3ba907b-bc5c-4910-8d85-ec7c8f7e1ef5.png)
![quadplane](https://user-images.githubusercontent.com/5248102/128892977-fce88e1e-4b5f-494e-b701-72bac3d29cb9.png)
![quadplane3](https://user-images.githubusercontent.com/5248102/128892971-7beca5c8-d411-47ef-9982-83bb6f17c1d7.png)

Resulting estimated coefficients are as the following
```
coefficients:
  c_d_wing_xz_lin: 9.857325322984973
  c_d_wing_xz_offset: 1.7608411983224699
  c_d_wing_xz_quad: 14.582778621159038
  c_l_wing_xz_lin: 7.354138666674714
  c_l_wing_xz_offset: 0.35340257538714354
  c_m_x_wing_xz_lin: -0.3033442956662163
  c_m_x_wing_xz_offset: -0.03993946355020013
  control_surface_0_c_d_delta: 10951.62612713498
  control_surface_0_c_l_delta: 10497.97558391014
  control_surface_0_c_m_x_delta: -3852.3259922164857
  control_surface_0_c_m_y_pitch_delta: 5035.6921908932945
  control_surface_0_c_m_z_delta: 3839.6249541143306
  control_surface_1_c_d_delta: 10375.609565622339
  control_surface_1_c_l_delta: 9922.166534704374
  control_surface_1_c_m_x_delta: -4074.37504132428
  control_surface_1_c_m_y_pitch_delta: 5102.2945765055065
  control_surface_1_c_m_z_delta: 4061.291386547589
  control_surface_2_c_d_delta: -514.1918623846291
  control_surface_2_c_l_delta: -515.4232458644941
  control_surface_2_c_m_x_delta: -292.93619788220064
  control_surface_2_c_m_y_pitch_delta: -76.40019871528516
  control_surface_2_c_m_z_delta: 293.8526143944141
  intercept: 0.0
  puller_c_m_drag_z_lin: 0.004014790982512653
  puller_c_m_drag_z_quad: 1.4474706831193287
  puller_c_m_leaver_lin: -5.03134649099124e-06
  puller_c_m_leaver_quad: 4.176651991566471e-06
  puller_c_m_rolling: -3.15253496309252
  puller_rot_drag_lin: 162.81484775042603
  puller_rot_thrust_lin: 2.9545896949737296
  puller_rot_thrust_quad: 187.5982069562628
  vertical_c_m_drag_z_lin: 0.11446584639530208
  vertical_c_m_drag_z_quad: 1.6122461652249056
  vertical_c_m_leaver_lin: 2.067426722873915
  vertical_c_m_leaver_quad: 21.107034117705382
  vertical_c_m_rolling: -0.012714552607306154
  vertical_rot_drag_lin: 0.13629339771115828
  vertical_rot_thrust_lin: -0.26934630204906407
  vertical_rot_thrust_quad: 33.27441141485527
metrics:
  R2: 0.9510818352935221
model:
  puller_:
  - dataframe_name: u4
    description: puller rotor
    position:
    - 0.22
    - 0
    - 0
    rotor_4: null
    rotor_axis:
    - 1
    - 0
    - 0
    turning_direction: -1
  vertical_:
  - dataframe_name: u0
    description: front right rotor
    position:
    - 0.35
    - 0.35
    - -0.07
    rotor_0: null
    rotor_axis:
    - 0
    - 0
    - -1
    turning_direction: -1
  - dataframe_name: u1
    description: back left rotor
    position:
    - -0.35
    - -0.35
    - -0.07
    rotor_1: null
    rotor_axis:
    - 0
    - 0
    - -1
    turning_direction: -1
  - dataframe_name: u2
    description: front left rotor
    position:
    - 0.35
    - -0.35
    - -0.07
    rotor_2: null
    rotor_axis:
    - 0
    - 0
    - -1
    turning_direction: 1
  - dataframe_name: u3
    description: back right rotor
    position:
    - -0.35
    - 0.35
    - -0.07
    rotor_3: null
    rotor_axis:
    - 0
    - 0
    - -1
    turning_direction: 1
  wing_:
  - control_surface_0: null
    dataframe_name: u5
    description: aileron_right
  - control_surface_1: null
    dataframe_name: u6
    description: aileron_left
  - control_surface_2: null
    dataframe_name: u7
    description: elevator
numper of samples: 6060
```
