### PR TITLE
Add flat plate wing model

### DIFF
--- a/Tools/parametric_model/src/models/aerodynamic_models/standard_wing_model.py
+++ b/Tools/parametric_model/src/models/aerodynamic_models/standard_wing_model.py
@@ -62,17 +62,18 @@ class StandardWingModel():
         flow_attached_region = 1 - stall_region
 
         # Compute Drag force coeffiecients:
-        X_wing_aero_frame[0, 0] = -flow_attached_region*q_x_A
-        X_wing_aero_frame[0, 1] = -flow_attached_region*angle_of_attack*q_x_A
+        X_wing_aero_frame[0, 0] = -flow_attached_region * q_x_A
+        X_wing_aero_frame[0, 1] = - \
+            flow_attached_region * q_x_A * angle_of_attack
         X_wing_aero_frame[0, 2] = -flow_attached_region * \
-            angle_of_attack**2*q_x_A
+            q_x_A * angle_of_attack**2
         X_wing_aero_frame[0, 3] = -stall_region * \
             (1 - math.sin(angle_of_attack)**2)*q_x_A
         X_wing_aero_frame[0, 4] = -stall_region * \
             (math.sin(angle_of_attack)**2)*q_x_A
         # Compute Lift force coefficients:
-        X_wing_aero_frame[2, 5] = -flow_attached_region*angle_of_attack*q_x_A
-        X_wing_aero_frame[2, 6] = -flow_attached_region*q_x_A
+        X_wing_aero_frame[2, 5] = -flow_attached_region*q_x_A
+        X_wing_aero_frame[2, 6] = -flow_attached_region*q_x_A*angle_of_attack
         X_wing_aero_frame[2, 7] = -stall_region * \
             q_x_A * math.sin(2*angle_of_attack)
 


### PR DESCRIPTION
Adding back the flat plate extension to the standard wing model. I think the mistake was in the pipeline switching the cl_0 and cl_alpha naming. 

These are the current results for the quadplane model:
![Screenshot from 2021-08-12 12-11-04](https://user-images.githubusercontent.com/18735094/129180060-d4061d9f-5dc3-4ac7-aa1a-c38fc5f9d052.png)

I think the lift curve looks nice and quite plausible. For the drag curve this is not yet the case. Hereby some of the parameters are negative, which should never be the case. I hope adding the constraints will somewhat help us here. i guess the main underlying issue here is that its hard to distinguish between rotor drag and wing drag since the quadplane is only flown in hover. 