### PR TITLE
Model yaw moment for directional stabilty

### DIFF
--- a/Tools/parametric_model/src/models/dynamics_model.py
+++ b/Tools/parametric_model/src/models/dynamics_model.py
@@ -107,9 +107,9 @@ class DynamicsModel():
             aoa_vec[i, :] = math.atan2(
                 airspeed_body_mat[i, 2], airspeed_body_mat[i, 0])
             sideslip_vec[i, :] = math.atan2(
-                airspeed_body_mat[i, 1], airspeed_body_mat[i, 0], sideslip_vec)
+                airspeed_body_mat[i, 1], airspeed_body_mat[i, 0])
 
-        airspeed_body_mat = np.hstack((airspeed_body_mat, aoa_vec))
+        airspeed_body_mat = np.hstack((airspeed_body_mat, aoa_vec, sideslip_vec))
         airspeed_body_df = pd.DataFrame(airspeed_body_mat, columns=[
             "V_air_body_x", "V_air_body_y", "V_air_body_z", "angle_of_attack", "angle_of_sideslip"])
         self.data_df = pd.concat(

--- a/Tools/parametric_model/src/models/quadplane_model.py
+++ b/Tools/parametric_model/src/models/quadplane_model.py
@@ -91,6 +91,7 @@ class QuadPlaneModel(DynamicsModel):
             airspeed_mat = self.data_df[[
                 "V_air_body_x", "V_air_body_y", "V_air_body_z"]].to_numpy()
             aoa_mat = self.data_df[["angle_of_attack"]].to_numpy()
+            sideslip_mat = self.data_df[["angle_of_sideslip"]].to_numpy()
             aero_model = StandardWingModel(self.aerodynamics_dict)
             X_aero_moments, aero_moments_coef_list = aero_model.compute_aero_moment_features(airspeed_mat, aoa_mat, sideslip_mat)
 

--- a/Tools/parametric_model/src/models/standardplane_model.py
+++ b/Tools/parametric_model/src/models/standardplane_model.py
@@ -89,9 +89,10 @@ class StandardPlaneModel(DynamicsModel):
             airspeed_mat = self.data_df[[
                 "V_air_body_x", "V_air_body_y", "V_air_body_z"]].to_numpy()
             aoa_mat = self.data_df[["angle_of_attack"]].to_numpy()
+            sideslip_mat = self.data_df[["angle_of_sideslip"]].to_numpy()
 
             aero_model = StandardWingModel(self.aerodynamics_dict)
-            X_aero_moments, aero_moments_coef_list = aero_model.compute_aero_moment_features(airspeed_mat, aoa_mat)
+            X_aero_moments, aero_moments_coef_list = aero_model.compute_aero_moment_features(airspeed_mat, aoa_mat, sideslip_mat)
 
             self.aero_moments_coef_list = aero_moments_coef_list
             self.X_aero_moments = X_aero_moments


### PR DESCRIPTION
**Problem Description**
This PR adds directional stability (yaw moment) by calculating a sideslip and estimating the coefficient for it. Previously there was no component generating yaw moment on the vehicle. 

- Added Calculation of sideslip and stored as data frames in "angle_of_sideslip"
- I have only added moment coefficients for sideslips intentionally. There are no side forces generated from sideslip


**Additional Context**
- Out of convenience, `AoA` dataframes were renamed as `angle_of_attack` so it stays consistent with the sideslip `angle_of_sideslip`