### PR TITLE
Make plotting happy by adding moments member

### DIFF
--- a/Tools/parametric_model/src/models/multirotor_model.py
+++ b/Tools/parametric_model/src/models/multirotor_model.py
@@ -99,6 +99,7 @@ class MultiRotorModel(DynamicsModel):
     def prepare_moment_regression_matrices(self):
         moment_mat = np.matmul(self.data_df[[
             "ang_acc_b_x", "ang_acc_b_y", "ang_acc_b_z"]].to_numpy(), self.moment_of_inertia)
+        self.y_moments = (moment_mat).flatten()
         self.data_df[["measured_moment_x", "measured_moment_y",
                      "measured_moment_z"]] = moment_mat
         


### PR DESCRIPTION
**Problem Description**
As reported in https://github.com/ethz-asl/data-driven-dynamics/issues/180, plotting has been failing with the following error

```
Traceback (most recent call last):
  File "Tools/parametric_model/generate_parametric_model.py", line 117, in <module>
    start_model_estimation(**vars(arg_list))
  File "Tools/parametric_model/generate_parametric_model.py", line 99, in start_model_estimation
    model.compute_residuals()
  File "/home/jaeyoung/dev/data-driven-dynamics/Tools/parametric_model/src/models/dynamics_model.py", line 487, in compute_residuals
    error_y_moments = y_moments_pred - self.y_moments
AttributeError: 'MultiRotorModel' object has no attribute 'y_moments'
Makefile:35: recipe for target 'estimate-model' failed
make: *** [estimate-model] Error 1
```

This is a quick WIP fix where the plotting tools are back for being happy now, but the axis of the data seems to be swapped (as expected) 
@pascalau FYI

![Figure_1](https://user-images.githubusercontent.com/5248102/152297110-283bd31e-8f71-4c5e-8ff8-0dbf2c54ebd3.png)
