### PR TITLE
Fix plotting

### DIFF
--- a/.github/workflows/sysid_test.yml
+++ b/.github/workflows/sysid_test.yml
@@ -27,6 +27,6 @@ jobs:
       - name: Run subsystem level tests on parametric model
         run: Tools/parametric_model/test_parametric_model.sh
       - name: Run multirotor_model estimation for system level test using resource ulog
-        run: make estimate-model model=quadrotor_model
+        run: make estimate-model model=quadrotor_model plot=False
       - name: Run multirotor_model estimation for system level test using resource csv
-        run: make estimate-model model=quadrotor_model log=resources/quadrotor_model.csv
+        run: make estimate-model model=quadrotor_model log=resources/quadrotor_model.csv plot=False

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ model?=quadrotor_model
 log?=${root_dir}/resources/${model}.ulg
 config?=${root_dir}/Tools/parametric_model/configs/${model}.yaml
 data_selection?=False
-plot?=False
+plot?=True
 
 submodulesupdate:
 	git submodule update --init --recursive

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ source setup.bash
 Generate the parametric model using a log file (ulog or csv):
 
 ```
-make estimate-model [model=<modeltype>] [config=<config_file_path>] [data_selection=<True/False>] log=<log_file_path>
+make estimate-model [model=<modeltype>] [config=<config_file_path>] [data_selection=<True/False>] [plot=<True/False>] log=<log_file_path>
 ```
 
 ### Pipeline Arguments

--- a/Tools/parametric_model/src/models/dynamics_model.py
+++ b/Tools/parametric_model/src/models/dynamics_model.py
@@ -480,8 +480,15 @@ class DynamicsModel():
 
         y_pred = self.optimizer.predict(self.X)
 
-        y_forces_pred = y_pred[0:self.y_forces.shape[0]]
-        y_moments_pred = y_pred[self.y_forces.shape[0]:]
+        y_forces_pred = np.zeros(self.y_forces.shape)
+        y_forces_pred[0::3] = y_pred[0:int(self.y_forces.shape[0]/3)]
+        y_forces_pred[1::3] = y_pred[int(self.y_forces.shape[0]/3):int(2*self.y_forces.shape[0]/3)]
+        y_forces_pred[2::3] = y_pred[int(2*self.y_forces.shape[0]/3):self.y_forces.shape[0]]
+
+        y_moments_pred = np.zeros(self.y_moments.shape)
+        y_moments_pred[0::3] = y_pred[self.y_moments.shape[0]:int(4*self.y_moments.shape[0]/3)]
+        y_moments_pred[1::3] = y_pred[int(4*self.y_moments.shape[0]/3):int(5*self.y_moments.shape[0]/3)]
+        y_moments_pred[2::3] = y_pred[int(5*self.y_moments.shape[0]/3):]
 
         error_y_forces = y_forces_pred - self.y_forces
         error_y_moments = y_moments_pred - self.y_moments
@@ -512,8 +519,16 @@ class DynamicsModel():
         y_pred = self.optimizer.predict(self.X)
 
         if (self.estimate_forces and self.estimate_moments):
-            y_forces_pred = y_pred[0:self.y_forces.shape[0]]
-            y_moments_pred = y_pred[self.y_forces.shape[0]:]
+            y_forces_pred = np.zeros(self.y_forces.shape)
+            y_forces_pred[0::3] = y_pred[0:int(self.y_forces.shape[0]/3)]
+            y_forces_pred[1::3] = y_pred[int(self.y_forces.shape[0]/3):int(2*self.y_forces.shape[0]/3)]
+            y_forces_pred[2::3] = y_pred[int(2*self.y_forces.shape[0]/3):self.y_forces.shape[0]]
+
+            y_moments_pred = np.zeros(self.y_moments.shape)
+            y_moments_pred[0::3] = y_pred[self.y_moments.shape[0]:int(4*self.y_moments.shape[0]/3)]
+            y_moments_pred[1::3] = y_pred[int(4*self.y_moments.shape[0]/3):int(5*self.y_moments.shape[0]/3)]
+            y_moments_pred[2::3] = y_pred[int(5*self.y_moments.shape[0]/3):]
+
             model_plots.plot_force_predictions(
                 self.y_forces, y_forces_pred, self.data_df["timestamp"])
             model_plots.plot_moment_predictions(


### PR DESCRIPTION
**Problem Description**
Plotting of the predictions were broken as reported in https://github.com/ethz-asl/data-driven-dynamics/issues/180

This was due to the fact that the axis order of the prediction / measurement has been flipped after https://github.com/ethz-asl/data-driven-dynamics/pull/176

This PR fixes the plotting by fixing the order of the matrices

**Testing**
The results can be reproduced with the following command.
```
make estimate-model plot=True
```
**Before PR**
![Residual_Visualization](https://user-images.githubusercontent.com/5248102/153222371-b29d3da4-3da2-49e5-865b-0ba32ab89292.png)
![Figure_1](https://user-images.githubusercontent.com/5248102/153222383-764c5462-ae41-4ff7-b5ac-7535ae172a66.png)
![Figure_2](https://user-images.githubusercontent.com/5248102/153222392-90bc4ab2-f323-428e-a518-a6ef68d56f8e.png)



**After PR**
![Residual_Visualization](https://user-images.githubusercontent.com/5248102/153222065-100eba87-85cd-4674-9760-fabadfe5126a.png)
![Figure_1](https://user-images.githubusercontent.com/5248102/153222000-ded2fc9b-afba-46a5-a9c5-79f82671d681.png)
![Figure_2](https://user-images.githubusercontent.com/5248102/153222011-c4fe6cb4-081c-4f49-b0fa-0babad3780e5.png)


**Additional Context**
- This is a follow up of https://github.com/ethz-asl/data-driven-dynamics/pull/181
- Fixes https://github.com/ethz-asl/data-driven-dynamics/issues/180