### PR TITLE
Add support for fixed wing models

### DIFF
--- a/.github/workflows/sysid_test.yml
+++ b/.github/workflows/sysid_test.yml
@@ -30,3 +30,5 @@ jobs:
         run: make estimate-model model=quadrotor_model plot=False
       - name: Run multirotor_model estimation for system level test using resource csv
         run: make estimate-model model=quadrotor_model log=resources/quadrotor_model.csv plot=False
+      - name: Run standardplane_model estimation for system level test using resource ulog
+        run: make estimate-model model=standardplane_model

--- a/Tools/parametric_model/configs/standardplane_model.yaml
+++ b/Tools/parametric_model/configs/standardplane_model.yaml
@@ -46,9 +46,9 @@ model_config:
           description: "rudder"
           dataframe_name: "u2"
 
-        - control_surface_4:
-          description: "flaps"
-          dataframe_name: "u3"
+        # - control_surface_4:
+        #   description: "flaps"
+        #   dataframe_name: "u3"
 
   aerodynamics:
     area: 1.2
@@ -57,7 +57,7 @@ model_config:
 
 dynamics_model_config:
   optimizer_config:
-    optimizer_class: "QPOptimizer"
+    optimizer_class: "LinearRegressor"
     optimzation_parameters:
     parameter_bounds:
       c_d_wing_xz_fp_max: !!python/tuple [1.8, 1.8]
@@ -114,7 +114,7 @@ dynamics_model_config:
         ulog_name:
           - "timestamp"
           - "output[2]" # Rudder
-          - "output[3]" # Flaps
+          # - "output[3]" # Flaps
           - "output[4]" # motor
           - "output[5]" # left aileron
           - "output[6]" # right aileron
@@ -122,7 +122,7 @@ dynamics_model_config:
         dataframe_name:
           - "timestamp"
           - "u2"
-          - "u3"
+          # - "u3"
           - "u4"
           - "u5"
           - "u6"
@@ -130,7 +130,7 @@ dynamics_model_config:
         actuator_type:
           - "timestamp"
           - "control_surface"
-          - "control_surface"
+          # - "control_surface"
           - "motor"
           - "control_surface"
           - "control_surface"

--- a/Tools/parametric_model/src/models/__init__.py
+++ b/Tools/parametric_model/src/models/__init__.py
@@ -4,3 +4,4 @@ from . import model_plots
 from .dynamics_model import DynamicsModel
 from .multirotor_model import MultiRotorModel
 from . model_config import ModelConfig
+from .standardplane_model import StandardPlaneModel

--- a/Tools/parametric_model/src/models/aerodynamic_models/standard_wing_model.py
+++ b/Tools/parametric_model/src/models/aerodynamic_models/standard_wing_model.py
@@ -115,7 +115,7 @@ class StandardWingModel():
         R_aero_to_body = Rotation.from_rotvec(
             [0, -angle_of_attack, 0]).as_matrix()
         X_wing_body_frame = R_aero_to_body @ X_wing_aero_frame
-
+        X_wing_body_frame = X_wing_body_frame.flatten()
         return X_wing_body_frame
 
     def compute_wing_moment_features(self, v_airspeed, angle_of_attack, angle_of_sideslip):
@@ -169,7 +169,7 @@ class StandardWingModel():
         R_aero_to_body = Rotation.from_rotvec(
             [0, -angle_of_attack, 0]).as_matrix()
         X_wing_body_frame = R_aero_to_body @ X_wing_aero_frame
-
+        X_wing_body_frame = X_wing_body_frame.flatten()
         return X_wing_body_frame
 
     def compute_aero_force_features(self, v_airspeed_mat, angle_of_attack_vec):
@@ -179,7 +179,6 @@ class StandardWingModel():
         v_airspeed_mat: numpy array of dimension (n,3) with columns for [v_a_x, v_a_y, v_a_z]
         angle_of_attack_vec: vector of size (n) with corresponding AoA values
         """
-        print("Starting computation of aero force features...")
         X_aero = self.compute_wing_force_features(
             v_airspeed_mat[0, :], angle_of_attack_vec[0])
         aero_features_bar = Bar(
@@ -190,10 +189,26 @@ class StandardWingModel():
             X_aero = np.vstack((X_aero, X_curr))
             aero_features_bar.next()
         aero_features_bar.finish()
-        wing_coef_list = ["c_d_wing_xz_offset", "c_d_wing_xz_lin", "c_d_wing_xz_quad",
-                          "c_d_wing_xz_fp_min", "c_d_wing_xz_fp_max",
-                          "c_l_wing_xz_offset", "c_l_wing_xz_lin", "c_l_wing_xz_fp"]
-        return X_aero, wing_coef_list
+        coef_dict = {
+            "c_d_wing_xz_offset": {"lin":{ "x": "c_d_wing_xz_offset_x","y": "c_d_wing_xz_offset_y","z":"c_d_wing_xz_offset_z"}},
+            "c_d_wing_xz_lin": {"lin":{ "x": "c_d_wing_xz_lin_x","y": "c_d_wing_xz_lin_y","z":"c_d_wing_xz_lin_z"}},
+            "c_d_wing_xz_quad": {"lin":{ "x": "c_d_wing_xz_quad_x","y": "c_d_wing_xz_quad_y","z":"c_d_wing_xz_quad_z"}},
+            "c_d_wing_xz_fp_min": {"lin":{ "x": "c_d_wing_xz_fp_min_x","y": "c_d_wing_xz_fp_min_y","z":"c_d_wing_xz_fp_min_z"}},
+            "c_d_wing_xz_fp_max": {"lin":{ "x": "c_d_wing_xz_fp_max_x","y": "c_d_wing_xz_fp_max_y","z":"c_d_wing_xz_fp_max_z"}},
+            "c_l_wing_xz_offset": {"lin":{ "x": "c_l_wing_xz_offset_x","y": "c_l_wing_xz_offset_y","z":"c_l_wing_xz_offset_z"}},
+            "c_l_wing_xz_lin": {"lin":{ "x": "c_l_wing_xz_lin_x","y": "c_l_wing_xz_lin_y","z":"c_l_wing_xz_lin_z"}},
+            "c_l_wing_xz_fp": {"lin":{ "x": "c_l_wing_xz_fp_x","y": "c_l_wing_xz_fp_y","z":"c_l_wing_xz_fp_z"}},
+        }
+        col_names = ["c_d_wing_xz_offset_x", "c_d_wing_xz_offset_y", "c_d_wing_xz_offset_z", 
+                    "c_d_wing_xz_lin_x", "c_d_wing_xz_lin_y", "c_d_wing_xz_lin_z",
+                    "c_d_wing_xz_quad_x", "c_d_wing_xz_quad_y", "c_d_wing_xz_quad_z",
+                    "c_d_wing_xz_fp_min_x", "c_d_wing_xz_fp_min_y", "c_d_wing_xz_fp_min_z",
+                    "c_d_wing_xz_fp_max_x", "c_d_wing_xz_fp_max_y", "c_d_wing_xz_fp_max_z",
+                    "c_l_wing_xz_offset_x", "c_l_wing_xz_offset_y", "c_l_wing_xz_offset_z",
+                    "c_l_wing_xz_lin_x", "c_l_wing_xz_lin_y", "c_l_wing_xz_lin_z", 
+                    "c_l_wing_xz_fp_x", "c_l_wing_xz_fp_y", "c_l_wing_xz_fp_z"]
+                
+        return X_aero, coef_dict, col_names
 
     def compute_aero_moment_features(self, v_airspeed_mat, angle_of_attack_vec, angle_of_sideslip_vec):
         """
@@ -213,7 +228,12 @@ class StandardWingModel():
             X_aero = np.vstack((X_aero, X_curr))
             aero_features_bar.next()
         aero_features_bar.finish()
-        wing_coef_list = ["c_m_x_wing_xz_offset",
-                          "c_m_x_wing_xz_lin", "c_m_z_wing_lin"]
-        aero_coef_list = wing_coef_list
-        return X_aero, aero_coef_list
+        coef_dict = {
+            "c_m_x_wing_xz_offset": {"rot":{ "x": "c_m_x_wing_xz_offset_x","y": "c_m_x_wing_xz_offset_y","z":"c_m_x_wing_xz_offset_z"}},
+            "c_m_x_wing_xz_lin": {"rot":{ "x": "c_m_x_wing_xz_lin_x","y": "c_m_x_wing_xz_lin_y","z":"c_m_x_wing_xz_lin_z"}},
+            "c_m_z_wing_lin": {"rot":{ "x": "c_m_z_wing_lin_x","y": "c_m_z_wing_lin_y","z":"c_m_z_wing_lin_z"}},
+        }
+        col_names = ["c_m_x_wing_xz_offset_x", "c_m_x_wing_xz_offset_y", "c_m_x_wing_xz_offset_z", 
+                    "c_m_x_wing_xz_lin_x", "c_m_x_wing_xz_lin_y", "c_m_x_wing_xz_lin_z",
+                    "c_m_z_wing_lin_x", "c_m_z_wing_lin_y", "c_m_z_wing_lin_z"]
+        return X_aero, coef_dict, col_names

--- a/Tools/parametric_model/src/models/standardplane_model.py
+++ b/Tools/parametric_model/src/models/standardplane_model.py
@@ -1,0 +1,145 @@
+__author__ = "Manuel Galliker"
+__maintainer__ = "Manuel Galliker"
+__license__ = "BSD 3"
+
+"""Model to estimate the system parameters of gazebos standart vtol quadplane:
+https://docs.px4.io/master/en/simulation/gazebo_vehicles.html#standard_vtol """
+
+
+import numpy as np
+import math
+
+from .dynamics_model import DynamicsModel
+from .rotor_models import RotorModel
+from sklearn.linear_model import LinearRegression
+from .model_config import ModelConfig
+from .aerodynamic_models import StandardWingModel, ControlSurfaceModel
+
+
+"""This model estimates forces and moments for quad plane as for example the standard vtol in gazebo."""
+
+
+class StandardPlaneModel(DynamicsModel):
+    def __init__(self, config_file, model_name="standardplane_model"):
+        self.config = ModelConfig(config_file)
+        super(StandardPlaneModel, self).__init__(
+            config_dict=self.config.dynamics_model_config)
+        self.mass = self.config.model_config["mass"]
+        self.moment_of_inertia = np.diag([self.config.model_config["moment_of_inertia"]["Ixx"],
+                                         self.config.model_config["moment_of_inertia"]["Iyy"], self.config.model_config["moment_of_inertia"]["Izz"]])
+
+        self.model_name = model_name
+
+        self.rotor_config_dict = self.config.model_config["actuators"]["rotors"]
+        self.aero_config_dict = self.config.model_config["actuators"]["control_surfaces"]
+        self.aerodynamics_dict = self.config.model_config["aerodynamics"]
+
+    def prepare_force_regression_matrices(self):
+        # Aerodynamics features
+        airspeed_mat = self.data_df[[
+            "V_air_body_x", "V_air_body_y", "V_air_body_z"]].to_numpy()
+        aoa_mat = self.data_df[["angle_of_attack"]].to_numpy()
+        aero_model = StandardWingModel(self.aerodynamics_dict)
+        X_aero_forces, aero_coef_list = aero_model.compute_aero_force_features(
+            airspeed_mat, aoa_mat)
+
+        self.aero_forces_coef_list = aero_coef_list
+        self.X_aero_forces = X_aero_forces
+
+        aero_config_dict = self.aero_config_dict
+        for aero_group in aero_config_dict.keys():
+            aero_group_list = self.aero_config_dict[aero_group]
+            if (self.estimate_forces):
+                X_force_collector = np.zeros(
+                    (3*self.v_airspeed_mat.shape[0], 2))
+
+            for config_dict in aero_group_list:
+                controlsurface_input_name = config_dict["dataframe_name"]
+                u_vec = self.data_df[controlsurface_input_name].to_numpy()
+                control_surface_model = ControlSurfaceModel(
+                    config_dict, self.aerodynamics_dict, u_vec)
+
+                if (self.estimate_forces):
+                    X_force_curr, curr_aero_forces_coef_list = control_surface_model.compute_actuator_force_matrix(
+                        airspeed_mat, aoa_mat)
+                    # Include aero group name in coefficient names:
+                    for i in range(len(curr_aero_forces_coef_list)):
+                        curr_aero_forces_coef_list[i] = list(config_dict.keys())[0] + "_" + \
+                            curr_aero_forces_coef_list[i]
+
+                    if 'X_aero_forces' not in vars():
+                        X_aero_forces = X_force_curr
+                        self.aero_forces_coef_list = curr_aero_forces_coef_list
+                    else:
+                        X_aero_forces = np.hstack(
+                            (X_aero_forces, X_force_curr))
+                        self.aero_forces_coef_list += curr_aero_forces_coef_list
+                    self.X_aero_forces = X_aero_forces
+
+        self.X_forces = np.hstack((self.X_rotor_forces, self.X_aero_forces))
+
+        # Accelerations
+        accel_mat = self.data_df[[
+            "acc_b_x", "acc_b_y", "acc_b_z"]].to_numpy()
+        force_mat = accel_mat * self.mass
+        self.y_forces = (force_mat).flatten()
+        self.data_df[["measured_force_x", "measured_force_y",
+                     "measured_force_z"]] = force_mat
+
+        # Set coefficients
+        self.coef_name_list.extend(
+            self.rotor_forces_coef_list + self.aero_forces_coef_list)
+
+    def prepare_moment_regression_matrices(self):
+        # Aerodynamics features
+        airspeed_mat = self.data_df[[
+            "V_air_body_x", "V_air_body_y", "V_air_body_z"]].to_numpy()
+        aoa_mat = self.data_df[["angle_of_attack"]].to_numpy()
+        sideslip_mat = self.data_df[["angle_of_sideslip"]].to_numpy()
+
+        aero_model = StandardWingModel(self.aerodynamics_dict)
+        X_aero_moments, aero_moments_coef_list = aero_model.compute_aero_moment_features(
+            airspeed_mat, aoa_mat, sideslip_mat)
+
+        self.aero_moments_coef_list = aero_moments_coef_list
+        self.X_aero_moments = X_aero_moments
+
+        aero_config_dict = self.aero_config_dict
+        for aero_group in aero_config_dict.keys():
+            aero_group_list = self.aero_config_dict[aero_group]
+
+            for config_dict in aero_group_list:
+                controlsurface_input_name = config_dict["dataframe_name"]
+                u_vec = self.data_df[controlsurface_input_name].to_numpy()
+                control_surface_model = ControlSurfaceModel(
+                    config_dict, self.aerodynamics_dict, u_vec)
+
+                if (self.estimate_moments):
+                    X_moment_curr, curr_aero_moments_coef_list = control_surface_model.compute_actuator_moment_matrix(
+                        airspeed_mat, aoa_mat)
+                    # Include aero group name in coefficient names:
+                    for i in range(len(curr_aero_moments_coef_list)):
+                        curr_aero_moments_coef_list[i] = list(config_dict.keys())[0] + "_" + \
+                            curr_aero_moments_coef_list[i]
+
+                    if 'X_aero_moments' not in vars():
+                        X_aero_moments = X_moment_curr
+                        self.aero_moments_coef_list = curr_aero_moments_coef_list
+                    else:
+                        X_aero_moments = np.hstack(
+                            (X_aero_moments, X_moment_curr))
+                        self.aero_moments_coef_list += curr_aero_moments_coef_list
+                    self.X_aero_moments = X_aero_moments
+
+        self.X_moments = np.hstack((self.X_rotor_moments, self.X_aero_moments))
+
+        # Angular acceleration
+        moment_mat = np.matmul(self.data_df[[
+            "ang_acc_b_x", "ang_acc_b_y", "ang_acc_b_z"]].to_numpy(), self.moment_of_inertia)
+        self.y_moments = moment_mat.flatten()
+        self.data_df[["measured_moment_x", "measured_moment_y",
+                     "measured_moment_z"]] = moment_mat
+
+        # Set coefficients
+        self.coef_name_list.extend(
+            self.rotor_moments_coef_list + self.aero_moments_coef_list)

--- a/Tools/parametric_model/src/models/standardplane_model.py
+++ b/Tools/parametric_model/src/models/standardplane_model.py
@@ -35,49 +35,6 @@ class StandardPlaneModel(DynamicsModel):
         self.aerodynamics_dict = self.config.model_config["aerodynamics"]
 
     def prepare_force_regression_matrices(self):
-        # Aerodynamics features
-        airspeed_mat = self.data_df[[
-            "V_air_body_x", "V_air_body_y", "V_air_body_z"]].to_numpy()
-        aoa_mat = self.data_df[["angle_of_attack"]].to_numpy()
-        aero_model = StandardWingModel(self.aerodynamics_dict)
-        X_aero_forces, aero_coef_list = aero_model.compute_aero_force_features(
-            airspeed_mat, aoa_mat)
-
-        self.aero_forces_coef_list = aero_coef_list
-        self.X_aero_forces = X_aero_forces
-
-        aero_config_dict = self.aero_config_dict
-        for aero_group in aero_config_dict.keys():
-            aero_group_list = self.aero_config_dict[aero_group]
-            if (self.estimate_forces):
-                X_force_collector = np.zeros(
-                    (3*self.v_airspeed_mat.shape[0], 2))
-
-            for config_dict in aero_group_list:
-                controlsurface_input_name = config_dict["dataframe_name"]
-                u_vec = self.data_df[controlsurface_input_name].to_numpy()
-                control_surface_model = ControlSurfaceModel(
-                    config_dict, self.aerodynamics_dict, u_vec)
-
-                if (self.estimate_forces):
-                    X_force_curr, curr_aero_forces_coef_list = control_surface_model.compute_actuator_force_matrix(
-                        airspeed_mat, aoa_mat)
-                    # Include aero group name in coefficient names:
-                    for i in range(len(curr_aero_forces_coef_list)):
-                        curr_aero_forces_coef_list[i] = list(config_dict.keys())[0] + "_" + \
-                            curr_aero_forces_coef_list[i]
-
-                    if 'X_aero_forces' not in vars():
-                        X_aero_forces = X_force_curr
-                        self.aero_forces_coef_list = curr_aero_forces_coef_list
-                    else:
-                        X_aero_forces = np.hstack(
-                            (X_aero_forces, X_force_curr))
-                        self.aero_forces_coef_list += curr_aero_forces_coef_list
-                    self.X_aero_forces = X_aero_forces
-
-        self.X_forces = np.hstack((self.X_rotor_forces, self.X_aero_forces))
-
         # Accelerations
         accel_mat = self.data_df[[
             "acc_b_x", "acc_b_y", "acc_b_z"]].to_numpy()
@@ -86,11 +43,25 @@ class StandardPlaneModel(DynamicsModel):
         self.data_df[["measured_force_x", "measured_force_y",
                      "measured_force_z"]] = force_mat
 
-        # Set coefficients
-        self.coef_name_list.extend(
-            self.rotor_forces_coef_list + self.aero_forces_coef_list)
+        # Aerodynamics features
+        airspeed_mat = self.data_df[[
+            "V_air_body_x", "V_air_body_y", "V_air_body_z"]].to_numpy()
+        aoa_mat = self.data_df[["angle_of_attack"]].to_numpy()
+        aero_model = StandardWingModel(self.aerodynamics_dict)
+        X_aero, coef_dict_aero, col_names_aero = aero_model.compute_aero_force_features(
+            airspeed_mat, aoa_mat)
+        self.data_df[col_names_aero] = X_aero
+        self.coef_dict.update(coef_dict_aero)
+        self.y_dict.update({"lin":{"x":"measured_force_x","y":"measured_force_y","z":"measured_force_z"}})
 
     def prepare_moment_regression_matrices(self):
+        # Angular acceleration
+        moment_mat = np.matmul(self.data_df[[
+            "ang_acc_b_x", "ang_acc_b_y", "ang_acc_b_z"]].to_numpy(), self.moment_of_inertia)
+        self.y_moments = moment_mat.flatten()
+        self.data_df[["measured_moment_x", "measured_moment_y",
+                     "measured_moment_z"]] = moment_mat
+
         # Aerodynamics features
         airspeed_mat = self.data_df[[
             "V_air_body_x", "V_air_body_y", "V_air_body_z"]].to_numpy()
@@ -98,11 +69,10 @@ class StandardPlaneModel(DynamicsModel):
         sideslip_mat = self.data_df[["angle_of_sideslip"]].to_numpy()
 
         aero_model = StandardWingModel(self.aerodynamics_dict)
-        X_aero_moments, aero_moments_coef_list = aero_model.compute_aero_moment_features(
+        X_aero, coef_dict_aero, col_names_aero = aero_model.compute_aero_moment_features(
             airspeed_mat, aoa_mat, sideslip_mat)
-
-        self.aero_moments_coef_list = aero_moments_coef_list
-        self.X_aero_moments = X_aero_moments
+        self.data_df[col_names_aero] = X_aero
+        self.coef_dict.update(coef_dict_aero)
 
         aero_config_dict = self.aero_config_dict
         for aero_group in aero_config_dict.keys():
@@ -111,35 +81,10 @@ class StandardPlaneModel(DynamicsModel):
             for config_dict in aero_group_list:
                 controlsurface_input_name = config_dict["dataframe_name"]
                 u_vec = self.data_df[controlsurface_input_name].to_numpy()
-                control_surface_model = ControlSurfaceModel(
-                    config_dict, self.aerodynamics_dict, u_vec)
+                control_surface_model = ControlSurfaceModel(config_dict, self.aerodynamics_dict, u_vec)
+                X_controls, coef_dict_controls, col_names_controls = control_surface_model.compute_actuator_moment_matrix(
+                    airspeed_mat, aoa_mat)
+                self.data_df[col_names_controls] = X_controls
+                self.coef_dict.update(coef_dict_controls)
 
-                if (self.estimate_moments):
-                    X_moment_curr, curr_aero_moments_coef_list = control_surface_model.compute_actuator_moment_matrix(
-                        airspeed_mat, aoa_mat)
-                    # Include aero group name in coefficient names:
-                    for i in range(len(curr_aero_moments_coef_list)):
-                        curr_aero_moments_coef_list[i] = list(config_dict.keys())[0] + "_" + \
-                            curr_aero_moments_coef_list[i]
-
-                    if 'X_aero_moments' not in vars():
-                        X_aero_moments = X_moment_curr
-                        self.aero_moments_coef_list = curr_aero_moments_coef_list
-                    else:
-                        X_aero_moments = np.hstack(
-                            (X_aero_moments, X_moment_curr))
-                        self.aero_moments_coef_list += curr_aero_moments_coef_list
-                    self.X_aero_moments = X_aero_moments
-
-        self.X_moments = np.hstack((self.X_rotor_moments, self.X_aero_moments))
-
-        # Angular acceleration
-        moment_mat = np.matmul(self.data_df[[
-            "ang_acc_b_x", "ang_acc_b_y", "ang_acc_b_z"]].to_numpy(), self.moment_of_inertia)
-        self.y_moments = moment_mat.flatten()
-        self.data_df[["measured_moment_x", "measured_moment_y",
-                     "measured_moment_z"]] = moment_mat
-
-        # Set coefficients
-        self.coef_name_list.extend(
-            self.rotor_moments_coef_list + self.aero_moments_coef_list)
+        self.y_dict.update({"rot":{"x":"measured_moment_x","y":"measured_moment_y","z":"measured_moment_z"}})


### PR DESCRIPTION
**Problem Description**
This is a WIP PR for adding support for fixedwing models for the data driven dynamics pipeline
- Added standard wing model
- Added aero control surface model

**Testing**
```
make estimate-model model=standardplane_model
```
![Figure_1](https://user-images.githubusercontent.com/5248102/157878379-463c1839-e65c-4bca-a3f6-07500b7c13fd.png)
![Figure_2](https://user-images.githubusercontent.com/5248102/157878381-6dca077c-efbc-46dc-914c-2ec76da94a5e.png)


**Discussion**
Since fixedwing models never stall in the log, the stall parameters are largely unobservable throughout the log.

This is correctly reported by the pipeline:
```
/home/jaeyoung/dev/data-driven-dynamics/Tools/parametric_model/src/optimizers/optimizer_base_template.py:79: RuntimeWarning: Feature detected that is only zero. Parameter c_d_wing_xz_fp_min is probably wrong.
  RuntimeWarning
/home/jaeyoung/dev/data-driven-dynamics/Tools/parametric_model/src/optimizers/optimizer_base_template.py:79: RuntimeWarning: Feature detected that is only zero. Parameter c_d_wing_xz_fp_max is probably wrong.
  RuntimeWarning
```
and can be visible in the lift/drag curve:
![Figure_6](https://user-images.githubusercontent.com/5248102/157878400-bb558f2b-cbf1-4541-9ad2-fbf52b99d72c.png)


