### PR TITLE
Disable auto data selection

### DIFF
--- a/Tools/parametric_model/generate_parametric_model.py
+++ b/Tools/parametric_model/generate_parametric_model.py
@@ -60,7 +60,7 @@ def start_model_estimation(config, log_path, data_selection=False, plot=False):
     print("Visual Data selection enabled: ", data_selection)
 
     # Flag for enabling automatic data selection.
-    auto_data_selection=True
+    auto_data_selection=False
 
     data_handler = DataHandler(config)
     data_handler.loadLogs(log_path)


### PR DESCRIPTION
**Problem Description**
From the discussion we had in https://github.com/ethz-asl/data-driven-dynamics/pull/186, my understanding was that we wanted the automatic data selection disabled by default

However, it was enabled by default, and resulting in the following failure
```
Traceback (most recent call last):
  File "Tools/parametric_model/generate_parametric_model.py", line 146, in <module>
    start_model_estimation(**vars(arg_list))
  File "Tools/parametric_model/generate_parametric_model.py", line 128, in start_model_estimation
    model.compute_residuals()
  File "/home/jaeyoung/dev/data-driven-dynamics/Tools/parametric_model/src/models/dynamics_model.py", line 486, in compute_residuals
    y_forces_pred[0::3] = y_pred[0:int(self.y_forces.shape[0]/3)]
ValueError: could not broadcast input array from shape (11838) into shape (14775)
Makefile:34: recipe for target 'estimate-model' failed
make: *** [estimate-model] Error 1
```

This PR disables it. @manumerous was this intentional that it was merged this way?