### PR TITLE
Fix plotting with dataselection

### DIFF
--- a/Tools/parametric_model/src/models/dynamics_model.py
+++ b/Tools/parametric_model/src/models/dynamics_model.py
@@ -481,19 +481,21 @@ class DynamicsModel():
     def compute_residuals(self):
 
         y_pred = self.optimizer.predict(self.X)
+        _,y_forces,_ = self.assemble_regression_matrices(["lin"])
+        _,y_moments,_ = self.assemble_regression_matrices(["rot"])
 
-        y_forces_pred = np.zeros(self.y_forces.shape)
-        y_forces_pred[0::3] = y_pred[0:int(self.y_forces.shape[0]/3)]
-        y_forces_pred[1::3] = y_pred[int(self.y_forces.shape[0]/3):int(2*self.y_forces.shape[0]/3)]
-        y_forces_pred[2::3] = y_pred[int(2*self.y_forces.shape[0]/3):self.y_forces.shape[0]]
+        y_forces_pred = np.zeros(y_forces.shape)
+        y_forces_pred[0::3] = y_pred[0:int(y_forces.shape[0]/3)]
+        y_forces_pred[1::3] = y_pred[int(y_forces.shape[0]/3):int(2*y_forces.shape[0]/3)]
+        y_forces_pred[2::3] = y_pred[int(2*y_forces.shape[0]/3):y_forces.shape[0]]
 
-        y_moments_pred = np.zeros(self.y_moments.shape)
-        y_moments_pred[0::3] = y_pred[self.y_moments.shape[0]:int(4*self.y_moments.shape[0]/3)]
-        y_moments_pred[1::3] = y_pred[int(4*self.y_moments.shape[0]/3):int(5*self.y_moments.shape[0]/3)]
-        y_moments_pred[2::3] = y_pred[int(5*self.y_moments.shape[0]/3):]
+        y_moments_pred = np.zeros(y_moments.shape)
+        y_moments_pred[0::3] = y_pred[y_moments.shape[0]:int(4*y_moments.shape[0]/3)]
+        y_moments_pred[1::3] = y_pred[int(4*y_moments.shape[0]/3):int(5*y_moments.shape[0]/3)]
+        y_moments_pred[2::3] = y_pred[int(5*y_moments.shape[0]/3):]
 
-        error_y_forces = y_forces_pred - self.y_forces
-        error_y_moments = y_moments_pred - self.y_moments
+        error_y_forces = y_forces_pred - y_forces
+        error_y_moments = y_moments_pred - y_moments
 
         stacked_error_y_forces = np.array(error_y_forces)
         acc_mat = stacked_error_y_forces.reshape((-1, 3))
@@ -522,34 +524,36 @@ class DynamicsModel():
         y_pred = self.optimizer.predict(self.X)
 
         if (self.estimate_forces and self.estimate_moments):
-            y_forces_pred = np.zeros(self.y_forces.shape)
-            y_forces_pred[0::3] = y_pred[0:int(self.y_forces.shape[0]/3)]
-            y_forces_pred[1::3] = y_pred[int(self.y_forces.shape[0]/3):int(2*self.y_forces.shape[0]/3)]
-            y_forces_pred[2::3] = y_pred[int(2*self.y_forces.shape[0]/3):self.y_forces.shape[0]]
+            _,y_forces,_ = self.assemble_regression_matrices(["lin"])
+            _,y_moments,_ = self.assemble_regression_matrices(["rot"])
+            y_forces_pred = np.zeros(y_forces.shape)
+            y_forces_pred[0::3] = y_pred[0:int(y_forces.shape[0]/3)]
+            y_forces_pred[1::3] = y_pred[int(y_forces.shape[0]/3):int(2*y_forces.shape[0]/3)]
+            y_forces_pred[2::3] = y_pred[int(2*y_forces.shape[0]/3):y_forces.shape[0]]
 
-            y_moments_pred = np.zeros(self.y_moments.shape)
-            y_moments_pred[0::3] = y_pred[self.y_moments.shape[0]:int(4*self.y_moments.shape[0]/3)]
-            y_moments_pred[1::3] = y_pred[int(4*self.y_moments.shape[0]/3):int(5*self.y_moments.shape[0]/3)]
-            y_moments_pred[2::3] = y_pred[int(5*self.y_moments.shape[0]/3):]
+            y_moments_pred = np.zeros(y_moments.shape)
+            y_moments_pred[0::3] = y_pred[y_moments.shape[0]:int(4*y_moments.shape[0]/3)]
+            y_moments_pred[1::3] = y_pred[int(4*y_moments.shape[0]/3):int(5*y_moments.shape[0]/3)]
+            y_moments_pred[2::3] = y_pred[int(5*y_moments.shape[0]/3):]
 
             model_plots.plot_force_predictions(
-                self.y_forces, y_forces_pred, self.data_df["timestamp"])
+                y_forces, y_forces_pred, self.data_df["timestamp"])
             model_plots.plot_moment_predictions(
-                self.y_moments, y_moments_pred, self.data_df["timestamp"])
+                y_moments, y_moments_pred, self.data_df["timestamp"])
             model_plots.plot_airspeed_and_AoA(
                 self.data_df[["V_air_body_x", "V_air_body_y", "V_air_body_z", "angle_of_attack"]], self.data_df["timestamp"])
 
         elif (self.estimate_forces):
             y_forces_pred = y_pred
             model_plots.plot_force_predictions(
-                self.y_forces, y_forces_pred, self.data_df["timestamp"])
+                y_forces, y_forces_pred, self.data_df["timestamp"])
             model_plots.plot_airspeed_and_AoA(
                 self.data_df[["V_air_body_x", "V_air_body_y", "V_air_body_z", "angle_of_attack"]], self.data_df["timestamp"])
 
         elif (self.estimate_moments):
             y_moments_pred = y_pred
             model_plots.plot_moment_predictions(
-                self.y_moments, y_moments_pred, self.data_df["timestamp"])
+                y_moments, y_moments_pred, self.data_df["timestamp"])
             model_plots.plot_airspeed_and_AoA(
                 self.data_df[["V_air_body_x", "V_air_body_y", "V_air_body_z", "angle_of_attack"]], self.data_df["timestamp"])
 

--- a/Tools/parametric_model/src/models/multirotor_model.py
+++ b/Tools/parametric_model/src/models/multirotor_model.py
@@ -83,7 +83,7 @@ class MultiRotorModel(DynamicsModel):
         accel_mat = self.data_df[[
             "acc_b_x", "acc_b_y", "acc_b_z"]].to_numpy()
         force_mat = accel_mat * self.mass
-        self.y_forces = (force_mat).flatten()
+        #self.y_forces = (force_mat).flatten()
         self.data_df[["measured_force_x", "measured_force_y",
                      "measured_force_z"]] = force_mat
 
@@ -99,7 +99,7 @@ class MultiRotorModel(DynamicsModel):
     def prepare_moment_regression_matrices(self):
         moment_mat = np.matmul(self.data_df[[
             "ang_acc_b_x", "ang_acc_b_y", "ang_acc_b_z"]].to_numpy(), self.moment_of_inertia)
-        self.y_moments = (moment_mat).flatten()
+        #self.y_moments = (moment_mat).flatten()
         self.data_df[["measured_moment_x", "measured_moment_y",
                      "measured_moment_z"]] = moment_mat
         


### PR DESCRIPTION
This is a fix for the issue that arises when plotting and manual data selection is performed. The issue stems from the self.y_forces and self.y_moments not being cropped during data selection which leads to wrong sizes during plotting. This pr fixes the issue by correctly passing cropped y_forces and y_moments to the residual calculation and plotting.