### PR TITLE
Turn off annotations for the covariance visualization

### DIFF
--- a/Tools/parametric_model/src/models/dynamics_model.py
+++ b/Tools/parametric_model/src/models/dynamics_model.py
@@ -604,7 +604,7 @@ class DynamicsModel():
             coef_dict = dict(zip(self.coef_name_list, coef_list))
             aerodynamics_plots.plot_liftdrag_curve(
                 coef_dict, self.aerodynamics_dict)
-
+        plt.tight_layout()
         plt.show()
         return
 

--- a/Tools/parametric_model/src/models/model_plots/linear_model_plots.py
+++ b/Tools/parametric_model/src/models/model_plots/linear_model_plots.py
@@ -48,5 +48,5 @@ def plot_covariance_mat(X, coef_name_list):
     df = pd.DataFrame(X, columns=coef_name_list)
     corrMatrix = df.corr()
     fig, ax = plt.subplots(1)
-    ax = sns.heatmap(corrMatrix, annot=True)
+    ax = sns.heatmap(corrMatrix, annot=False)
     ax.set_title('Coefficient covariance')


### PR DESCRIPTION
**Problem Description**
This commit turns off the annotation and uses a tight layout for the plots

- Before PR
![Figure_51](https://user-images.githubusercontent.com/5248102/157848905-b1b3f3b8-5c53-4e07-b967-7f44029cce16.png)

- After PR
![Figure_5](https://user-images.githubusercontent.com/5248102/157848896-aacd52b2-9f8f-451c-a304-2622dc8b7f95.png)

**Additional Context**
- Fixes https://github.com/ethz-asl/data-driven-dynamics/issues/167