### PR TITLE
Add support for multi ID topics

### DIFF
--- a/Tools/parametric_model/configs/dynamics_model_test_config.yaml
+++ b/Tools/parametric_model/configs/dynamics_model_test_config.yaml
@@ -43,6 +43,13 @@ dynamics_model_config:
   estimate_angular_acceleration: False
   data:
     required_ulog_topics:
+      actuator_outputs:
+        ulog_name:
+          - "timestamp"
+          - "output[0]"
+          - "output[1]"
+          - "output[2]"
+          - "output[3]"
       vehicle_local_position:
         ulog_name:
           - "timestamp"

--- a/Tools/parametric_model/configs/quadrotor_model.yaml
+++ b/Tools/parametric_model/configs/quadrotor_model.yaml
@@ -104,6 +104,7 @@ dynamics_model_config:
       #     - "ang_acc_b_y"
       #     - "ang_acc_b_z"
       actuator_outputs:
+        id: 0
         ulog_name:
           - "timestamp"
           - "output[0]"

--- a/Tools/parametric_model/src/models/dynamics_model.py
+++ b/Tools/parametric_model/src/models/dynamics_model.py
@@ -38,7 +38,7 @@ __license__ = "BSD 3"
 
 from src.tools.math_tools import cropped_sym_sigmoid
 from src.tools.quat_utils import quaternion_to_rotation_matrix
-from src.tools.dataframe_tools import compute_flight_time, resample_dataframe_list
+from src.tools.dataframe_tools import resample_dataframe_list
 from src.tools.ulog_tools import load_ulog, pandas_from_topic
 from .model_plots import model_plots, aerodynamics_plots, linear_model_plots
 from .rotor_models import RotorModel, BiDirectionalRotorModel, TiltingRotorModel, ChangingAxisRotorModel

--- a/Tools/parametric_model/src/tools/data_handler.py
+++ b/Tools/parametric_model/src/tools/data_handler.py
@@ -159,6 +159,8 @@ class DataHandler(object):
             
             if topic_type == "actuator_outputs":
                 fts = compute_flight_time(curr_df)
+            elif topic_type == "actuator_controls_0":
+                fts = compute_flight_time(curr_df)
             
             curr_df = curr_df[topic_dict["ulog_name"]]
             if "dataframe_name" in topic_dict.keys():

--- a/Tools/parametric_model/src/tools/dataframe_tools.py
+++ b/Tools/parametric_model/src/tools/dataframe_tools.py
@@ -46,7 +46,7 @@ PWM_THRESHOLD = 1000
 ACTUATOR_CONTROLS_THRESHOLD = -0.2
 
 
-def compute_flight_time(ulog, pwm_threshold=None, control_threshold=None):
+def compute_flight_time(act_df, pwm_threshold=None, control_threshold=None):
     """This function computes the flight time by a simple thresholding of actuator outputs or control values. 
     This works usually well for logs from the simulator or mission flights. But in some cases the assumption of an actuator output staying higher than the trsehhold for the hole flight might not be valid."""
 
@@ -56,25 +56,8 @@ def compute_flight_time(ulog, pwm_threshold=None, control_threshold=None):
     if control_threshold is None:
         control_threshold = ACTUATOR_CONTROLS_THRESHOLD
 
-    topic_type_list = []
-    for ulog_data_element in ulog._data_list:
-        topic_type_list.append(ulog_data_element.name)
+    act_df_crp = act_df[act_df.iloc[:, 4] > pwm_threshold]
 
-    if "actuator_outputs" in topic_type_list:
-        act_df = pandas_from_topic(ulog, ["actuator_outputs"])
-        # choose first actuator data
-        act_df_crp = act_df[act_df.iloc[:, 4] > pwm_threshold]
-
-    # special case for aero mini tilt wing for asl
-    elif "actuator_controls_0" in topic_type_list:
-        act_df = pandas_from_topic(ulog, ["actuator_controls_0"])
-        # choose first actuator data
-        act_df_crp = act_df[act_df.iloc[:, 4] > control_threshold]
-
-    else:
-        print("could not select flight time due to missing actuator topic")
-        exit(1)
-        # set start and end time of flight duration
     t_start = act_df_crp.iloc[1, 0]
     t_end = act_df_crp.iloc[(act_df_crp.shape[0]-1), 0]
     flight_time = {"t_start": t_start, "t_end": t_end}

--- a/Tools/parametric_model/src/tools/ulog_tools.py
+++ b/Tools/parametric_model/src/tools/ulog_tools.py
@@ -50,11 +50,11 @@ def load_ulog(rel_ulog_path):
     return ulog
 
 
-def pandas_from_topic(ulog, topic_list):
+def pandas_from_topic(ulog, topic_list, id = 0):
     assert type(topic_list) is list, 'topic_list input must be a list'
     topics_df = pd.DataFrame()
     for topic in topic_list:
-        topic_data = ulog.get_dataset(topic)
+        topic_data = ulog.get_dataset(topic, id)
         curr_df = pd.DataFrame.from_dict(topic_data.data)
         if topics_df.empty:
             topics_df = curr_df


### PR DESCRIPTION
**Problem Description**
uORB topics support [multi instance publishing](https://docs.px4.io/v1.12/en/middleware/uorb.html#multi-instance), however this pipeline does not consider this and always default to `id = 0`

This is a problem with the recent control allocation added in PX4 where `actuator_outputs` essentially are published by multiple entitites and therefore published on different channels

**Proposed Solution**
This commit adds support for multi ID uorb topics. The ID of the topic can be now specified in the configuration file when specifying uORB topics

```
data:
    required_ulog_topics:
      actuator_outputs:
        id: 0
```

**Additional Context**
- Fixes https://github.com/ethz-asl/data-driven-dynamics/issues/196