### PR TITLE
enhance: add config and extractor for global-singularity free approach

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ make estimate-model model=quadrotor_model log=resources/quadrotor_model.ulg
 
 ## Extract PX4 Parameters from Aerodynamic Model (currently only supported for Fixed Wing Vehicles)
 
-In order to extract important longitudinal trimming parameters directly from the identified aerodynamic model, just add the flag --extraction True to the function call. The extracted parameters are then saved in the same folder as the model results. The configuration has to include the extractor model that is to be used (e.g. the FixedWingExtractorModel) and an extractor configuration, containing user-determined minimum and maximum flight speeds (and optionally a cruise flight speed).
+In order to extract important longitudinal trimming parameters directly from the identified aerodynamic model, just add the flag `--extraction True` to the function call. The extracted parameters are then saved in the same folder as the model results. The configuration has to include the extractor model that is to be used (e.g. the FixedWingExtractorModel) and an extractor configuration, containing user-determined minimum and maximum flight speeds (and optionally a cruise flight speed).
 
 In preparation for a potentially more model-based control approach in the PX4-Autopilot, more parameters then currently required as estimated. Currently not supported parameters are marked correspondingly:
 

--- a/Tools/parametric_model/configs/fixedwing_singularityfree_model.yaml
+++ b/Tools/parametric_model/configs/fixedwing_singularityfree_model.yaml
@@ -3,13 +3,10 @@ model_name: "Gazebo Standard Plane"
 model_type: "Standard Plane Longitudinal Model"
 model_class: "GlobalSingularityFreeModel"
 
-# extractor_class: "SingularityFreeExtractorModel"
-# extractor_config:
-#   vmin: 8.0
-#   vmax: 20.0
-
-extractor_class: "Not implemented"
-extractor_config: "Not implemented"
+extractor_class: "SingularityFreeExtractorModel"
+extractor_config:
+  vmin: 8.0
+  vmax: 20.0
 
   # all vectors in FRD body frame if not specified otherwise
 model_config:
@@ -38,7 +35,7 @@ dynamics_model_config:
     optimizer_class: "LinearRegressor"
   estimate_forces: True
   estimate_moments: True
-  use_sysid_maneuvers: True
+  use_sysid_maneuvers: False
   # only set at most one of the following parameters to True
   use_with_thrust_only: False
   use_zero_thrust_only: False

--- a/Tools/parametric_model/configs/fixedwing_singularityfree_model.yaml
+++ b/Tools/parametric_model/configs/fixedwing_singularityfree_model.yaml
@@ -1,0 +1,150 @@
+# general information
+model_name: "Gazebo Standard Plane"
+model_type: "Standard Plane Longitudinal Model"
+model_class: "GlobalSingularityFreeModel"
+
+# extractor_class: "SingularityFreeExtractorModel"
+# extractor_config:
+#   vmin: 8.0
+#   vmax: 20.0
+
+extractor_class: "Not implemented"
+extractor_config: "Not implemented"
+
+  # all vectors in FRD body frame if not specified otherwise
+model_config:
+  mass: 1.45
+  moment_of_inertia:
+    Ixx: 0.107
+    Iyy: 0.256
+    Izz: 0.356
+  actuators:
+    rotors:
+      # All rotors in the same group will share the coefficients
+      puller_:
+        - rotor:
+          description: "puller rotor"
+          rotor_type: "LinearRotorModel"
+          dataframe_name: "throttle"
+
+  aerodynamics:
+    area: 0.41
+    chord: 0.19
+    stall_angle_deg: 20
+    sig_scale_factor: 30
+
+dynamics_model_config:
+  optimizer_config:
+    optimizer_class: "LinearRegressor"
+  estimate_forces: True
+  estimate_moments: True
+  use_sysid_maneuvers: True
+  # only set at most one of the following parameters to True
+  use_with_thrust_only: False
+  use_zero_thrust_only: False
+  resample_freq: 50.0
+  estimate_angular_acceleration: False
+  data:
+    required_ulog_topics:
+      actuator_outputs:
+        id: 1
+        ulog_name:
+          - "timestamp"
+          - "output[0]"
+          - "output[1]"
+          - "output[3]"
+          - "output[4]"
+          - "output[6]"
+        dataframe_name:
+          - "timestamp"
+          - "u0"
+          - "u1"
+          - "u3"
+          - "u4"
+          - "u6"
+        actuator_type:
+          - "timestamp"
+          - "control_surface"
+          - "control_surface"
+          - "control_surface"
+          - "motor"
+          - "control_surface"
+      vehicle_local_position:
+        ulog_name:
+          - "timestamp"
+          - "vx"
+          - "vy"
+          - "vz"
+      vehicle_attitude:
+        ulog_name:
+          - "timestamp"
+          - "q[0]"
+          - "q[1]"
+          - "q[2]"
+          - "q[3]"
+        dataframe_name:
+          - "timestamp"
+          - "q0"
+          - "q1"
+          - "q2"
+          - "q3"
+      vehicle_angular_velocity:
+        ulog_name:
+          - "timestamp"
+          - "xyz[0]"
+          - "xyz[1]"
+          - "xyz[2]"
+          - "xyz_derivative[0]"
+          - "xyz_derivative[1]"
+          - "xyz_derivative[2]"
+        dataframe_name:
+          - "timestamp"
+          - "ang_vel_x"
+          - "ang_vel_y"
+          - "ang_vel_z"
+          - "ang_acc_b_x"
+          - "ang_acc_b_y"
+          - "ang_acc_b_z"
+      sensor_combined:
+        ulog_name:
+          - "timestamp"
+          - "accelerometer_m_s2[0]"
+          - "accelerometer_m_s2[1]"
+          - "accelerometer_m_s2[2]"
+        dataframe_name:
+          - "timestamp"
+          - "acc_b_x"
+          - "acc_b_y"
+          - "acc_b_z"
+      manual_control_setpoint:
+        ulog_name:
+          - "timestamp"
+          - "aux1"
+        dataframe_name:
+          - "timestamp"
+          - "aux1"
+      vehicle_thrust_setpoint:
+        ulog_name:
+          - "timestamp"
+          - "xyz[0]"
+        dataframe_name:
+          - "timestamp"
+          - "throttle"
+      vehicle_torque_setpoint:
+        ulog_name:
+          - "timestamp"
+          - "xyz[0]"
+          - "xyz[1]"
+          - "xyz[2]"
+        dataframe_name:
+          - "timestamp"
+          - "aileron" # differential input to ailerons
+          - "elevator" # elevator input
+          - "rudder" # rudder input
+      vehicle_land_detected:
+        ulog_name:
+          - "timestamp"
+          - "landed"
+        dataframe_name:
+          - "timestamp"
+          - "landed"

--- a/Tools/parametric_model/generate_parametric_model.py
+++ b/Tools/parametric_model/generate_parametric_model.py
@@ -123,7 +123,7 @@ def start_model_estimation(config, log_path, data_selection="none", plot=False, 
         
         extractor.compute_px4_params()
         px4_params = extractor.get_px4_params()
-        extractor.save_px4_params_to_yaml('model_results/' + data_handler.config.extractor_class + '_px4_params')
+        extractor.save_px4_params_to_yaml('model_results/')
 
     if plot:
         model.compute_residuals()

--- a/Tools/parametric_model/src/models/__init__.py
+++ b/Tools/parametric_model/src/models/__init__.py
@@ -6,3 +6,4 @@ from .dynamics_model import DynamicsModel
 from .multirotor_model import MultiRotorModel
 from . model_config import ModelConfig
 from .simple_fixedwing_model import SimpleFixedWingModel
+from .global_singularityfree_model import GlobalSingularityFreeModel

--- a/Tools/parametric_model/src/models/extractor_models/__init__.py
+++ b/Tools/parametric_model/src/models/extractor_models/__init__.py
@@ -1,1 +1,2 @@
 from .fixedwing_extractor_model import FixedWingExtractorModel
+from .singularityfree_extractor_model import SingularityFreeExtractorModel

--- a/Tools/parametric_model/src/models/extractor_models/fixedwing_extractor_model.py
+++ b/Tools/parametric_model/src/models/extractor_models/fixedwing_extractor_model.py
@@ -90,14 +90,14 @@ class FixedWingExtractorModel():
         """
         return self.px4_params
 
-    def save_px4_params_to_yaml(self, output_file):
+    def save_px4_params_to_yaml(self, output_folder):
         """
         Save the extracted px4 parameters to a yaml file
 
-        :param output_file: path to the output file
+        :param output_folder: path to the output file
         """
         timestr = time.strftime("%Y-%m-%d-%H-%M-%S")
-        file_path = output_file + "_" + timestr + ".yaml"
+        file_path = output_folder + self.model_name + '_px4_params' + "_" + timestr + ".yaml"
 
         with open(file_path, 'w') as outfile:
             yaml.dump(self.px4_params, outfile, default_flow_style=False)

--- a/Tools/parametric_model/src/models/extractor_models/singularityfree_extractor_model.py
+++ b/Tools/parametric_model/src/models/extractor_models/singularityfree_extractor_model.py
@@ -1,0 +1,395 @@
+"""
+ *
+ * Copyright (c) 2023 Julius Schlapbach
+ *               2023 Autonomous Systems Lab ETH Zurich
+ * All rights reserved.
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name Data Driven Dynamics nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+"""
+
+__author__ = "Julius Schlapbach"
+__maintainer__ = "Julius Schlapbach"
+__license__ = "BSD 3"
+
+from src.models.model_config import ModelConfig
+
+import numpy as np
+import time
+import yaml
+from scipy.optimize import fsolve
+
+
+class SingularityFreeExtractorModel():
+    def __init__(self, config, model_config_file, coefficients):
+        """
+        Initialize the global singularity-free extractor model.
+        The configuration dictionary should at least contain specifications for minimum and maximum airspeed for the aircraft (strutural and stall limits).
+        Optionally, a criuse flight speed can be specified. Otherwise, the maximum range airspeed is used as cruise speed.
+
+        :param config: configuration dictionary
+        :param model_config_file: path to model configuration file
+        :param coefficients: dictionary with identified aerodynamic coefficients
+        """
+        print("\n\n===============================================================================")
+        print("                        PX4 Parameter Extraction                               ")
+        print("===============================================================================")
+
+        self.model_name = "singularityfree_extractor"
+        self.config = config
+        self.model_config = ModelConfig(model_config_file)
+        self.aero_params = coefficients
+
+        self.gravity = 9.81
+        self.rho = 1.225
+
+        self.mass = self.model_config.model_config["mass"]
+        self.area = self.model_config.model_config['aerodynamics']["area"]
+        self.chord = self.model_config.model_config['aerodynamics']["chord"]
+        self.span = self.area / self.chord
+
+        self.px4_params = {}
+
+        # check that all required aerodynamic coefficients are given
+        aero_coeffs = ["cmdelta", "phifv_11", "phifv_12", "phifv_13", "phifv_21", "phifv_22",
+                       "phifv_23", "phifv_31", "phifv_32", "phifv_33", "puller_ct", "puller_cmt"]
+        for coeff in aero_coeffs:
+            if not coeff in self.aero_params:
+                raise ValueError(
+                    "Coefficient {} not found in identified coefficient dictionary".format(coeff))
+
+    def get_px4_params(self):
+        """
+        Getter function for the extarcted px4 parameters
+
+        :return: dictionary with extracted px4 parameters
+        """
+        return self.px4_params
+
+    def save_px4_params_to_yaml(self, output_file):
+        """
+        Save the extracted px4 parameters to a yaml file
+
+        :param output_file: path to the output file
+        """
+        timestr = time.strftime("%Y-%m-%d-%H-%M-%S")
+        file_path = output_file + "_" + timestr + ".yaml"
+
+        with open(file_path, 'w') as outfile:
+            yaml.dump(self.px4_params, outfile, default_flow_style=False)
+
+        return
+
+    def compute_px4_params(self):
+        """
+        Main function to compute the px4 parameters
+        To see which parameters are computed, check the README of the repository
+        """
+        print('Starting parameter extraction with the following configuration parameters:')
+        print('Minimum Airspeed: ', self.config['vmin'])
+        print('Maximum Airspeed: ', self.config['vmax'])
+        print('Cruise speed: ', self.config['vcruise']
+              if 'vcruise' in self.config else 'speed for maximum range')
+
+        self.px4_params['FW_AIRSPD_MIN'] = self.config['vmin']
+        self.px4_params['FW_AIRSPD_MAX'] = self.config['vmax']
+
+        self.px4_params['TRIM_PITCH_MAX_RANGE'], self.px4_params['FW_AIRSPD_MAX_RANGE'] = self.get_max_range_params()
+        self.px4_params['FW_AIRSPD_TRIM'] = self.config['vcruise'] if 'vcruise' in self.config else self.px4_params['FW_AIRSPD_MAX_RANGE']
+
+        self.px4_params['TRIM_PITCH_MIN_SINK'], self.px4_params['FW_AIRSPD_MIN_SINK'], self.px4_params['FW_T_SINK_MIN'] = self.get_min_sink_params()
+
+        self.px4_params['FW_THR_TRIM'], self.px4_params['FW_PSP_OFF'], self.px4_params['TRIM_PITCH'] = self.get_cruise_params(
+            self.px4_params['FW_AIRSPD_TRIM'])
+
+        self.px4_params['FW_DTRIM_P_VMIN'], self.px4_params['FW_THR_VMIN'] = self.get_min_vel_params(
+            self.config['vmin'], self.px4_params['TRIM_PITCH'])
+
+        self.px4_params['TRIM_PITCH_MAX_SINK'], self.px4_params['FW_T_SINK_MAX'], self.px4_params['FW_DTRIM_P_VMAX'], self.px4_params['FW_THR_VMAX'] = self.get_max_vel_params(
+            self.config['vmax'], self.px4_params['TRIM_PITCH'])
+
+        self.px4_params['FW_T_CLIMB_MAX'], self.px4_params['TRIM_PITCH_MAX_CLIMB'] = self.get_max_climb_params(
+            self.px4_params['FW_AIRSPD_MIN_SINK'])
+
+        print("\n===============================================================================")
+        print("                      END PX4 Parameter Extraction                             ")
+        print("===============================================================================")
+
+        return
+
+    def cL(self, alpha):
+        """
+        This function computes the lift coefficient.
+
+        :param alpha: angle of attack
+        :return: lift coefficient
+        """
+        return self.aero_params['phifv_13'] * np.cos(2 * alpha) + 0.5 * (self.aero_params['phifv_33'] - self.aero_params['phifv_11']) * np.sin(2 * alpha)
+
+    def cD(self, alpha):
+        """
+        This function computes the drag coefficient.
+
+        :param alpha: angle of attack
+        :return: drag coefficient
+        """
+        return 0.5 * ((self.aero_params['phifv_11'] - self.aero_params['phifv_33']) * np.cos(2 * alpha) + 2 * self.aero_params['phifv_13'] * np.sin(2 * alpha) + self.aero_params['phifv_33'] + self.aero_params['phifv_11'])
+
+    def lift(self, alpha, delta_e, velocity):
+        """
+        This function computes the lift force.
+
+        :param alpha: angle of attack
+        :param delta_e: elevator deflection
+        :return: lift force
+        """
+        return 0.5 * self.rho * self.area * (velocity ** 2) * self.cL(alpha)
+
+    def drag(self, alpha, velocity):
+        """
+        This function computes the drag force.
+
+        :param alpha: angle of attack
+        :return: drag force
+        """
+        return 0.5 * self.rho * self.area * (velocity ** 2) * self.cD(alpha)
+
+    def thrust(self, throttle):
+        """
+        This function computes the thrust force.
+
+        :param throttle: throttle setting
+        :return: thrust force
+        """
+        return self.aero_params['puller_ct'] * throttle
+
+    def zero_moment_trim(self, alpha, throttle, velocity):
+        """
+        This function computes the elevator trim for zero resulting pitching moment.
+        CAUTION: For simplicity, it is assumed that the sideslip velocity V_y is zero in trimmed flight.
+
+        :param alpha: angle of attack
+        :return: elevator trim
+        """
+        gamma = np.arctan2(self.cD(alpha), self.cL(alpha))
+
+        Vx = np.sqrt((velocity ** 2) / (1 + (np.tan(gamma) ** 2)))
+        Vz = np.tan(gamma) * Vx
+
+        eta = velocity
+        constant = - 0.5 * self.rho * self.area * eta
+        vf_x = self.chord**2 * constant * Vx
+        vf_z = self.chord**2 * constant * Vz
+
+        return - (vf_x * self.aero_params['phifv_21'] + vf_z * self.aero_params['phifv_23'] + self.aero_params['puller_cmt'] * throttle) / self.aero_params['cmdelta']
+
+    def get_max_range_params(self):
+        """
+        This function computes the elevator trim and flight speed for maximum range (gliding flight)
+        Condition for max range: max cL/cD
+
+        :return: elevator trim and flight speed
+        """
+        print("Computing max range parameters...")
+        alphas = np.linspace(-20 * np.pi / 180, 20 * np.pi / 180, 500)
+
+        airspeeds = np.zeros(len(alphas))
+        for i in range(len(alphas)):
+            airspeeds[i], _ = self.get_flight_vel_zero_thrust(alphas[i])
+
+        trims = self.zero_moment_trim(alphas, np.zeros(len(alphas)), airspeeds)
+        lift_drag_ratio = self.cL(alphas) / self.cD(alphas)
+
+        # find max lift/drag ratio, which corresponds to the max range flight state
+        idx = np.argmax(lift_drag_ratio)
+        elevator_trim = trims[idx]
+        airspeed = airspeeds[idx]
+
+        print("Max range parameters computed successfully:")
+        print("Elevator trim: ", elevator_trim,
+              "Speed for max range: ", airspeed, '\n')
+
+        return float(elevator_trim), float(airspeed)
+
+    def get_min_sink_params(self):
+        """
+        This function computes the elevator trim, flight speed and sink rate for the minimum sink rate flight state (gliding flight)
+        Condition for min sink rate: max lift^3 / drag^2
+
+        :return: elevator trim, flight speed and sink rate
+        """
+        print("Computing min sink parameters...")
+        alphas = np.linspace(-30 * np.pi / 180, 30 * np.pi / 180, 500)
+
+        airspeeds = np.zeros(len(alphas))
+        gammas = np.zeros(len(alphas))
+        for i in range(len(alphas)):
+            airspeeds[i], gammas[i] = self.get_flight_vel_zero_thrust(
+                alphas[i])
+
+        trims = self.zero_moment_trim(alphas, 0.0, airspeeds)
+
+        # find max lift^3 / drag^2 ratio, which corresponds to the minimum sink rate flight state
+        ratio = (self.cL(alphas) ** 3) / (self.cD(alphas) ** 2)
+        idx = np.argmax(ratio)
+        airspeed = airspeeds[idx]
+        gamma = gammas[idx]
+        elevator_trim = trims[idx]
+
+        min_sink_rate = airspeed / (np.sqrt(1 + 1 / (np.tan(- gamma) ** 2)))
+
+        print("Min sink parameters computed successfully.")
+        print("Elevator trim: ", elevator_trim, "Speed for min sink: ",
+              airspeed, "Min sink rate: ", min_sink_rate, '\n')
+        return float(elevator_trim), float(airspeed), float(min_sink_rate)
+
+    def get_cruise_params(self, airspeed: float):
+        """
+        This function computes the elevator trim and throttle setting for level flight
+        The velocity (airspeed) is given as an input
+
+        :param airspeed: flight speed
+        :return: elevator trim, throttle setting and level flight pitch (= angle of attack)
+        """
+        print("Computing cruise flight parameters...")
+
+        throttle_setting, pitch_level_flight, elevator_trim = self.get_level_flight_params(
+            airspeed)
+
+        print("Level flight parameters computed successfully.")
+        print("Level flight pitch: ", pitch_level_flight,
+              "Throttle setting: ", throttle_setting, "Level flight trim: ", elevator_trim, '\n')
+        return float(throttle_setting), float(pitch_level_flight), float(elevator_trim)
+
+    def get_min_vel_params(self, vmin: float, level_trim: float):
+        """
+        This function computes the elevator trim and flight speed for minimum velocity (user-provided).
+
+        :param vmin: minimum velocity
+        :return: differential elevator trim (to cruise trim) and throttle setting at minimum flight speed
+        """
+        print("Computing min velocity parameters...")
+
+        throttle_setting, _, elevator_trim = self.get_level_flight_params(vmin)
+        diff_trim = elevator_trim - level_trim
+
+        print("Min velocity parameters computed successfully.")
+        print("Differential elevator trim: ", diff_trim,
+              "at user-specified min velocity: ", vmin,
+              'Throttle setting', throttle_setting, '\n')
+        return float(diff_trim), float(throttle_setting)
+
+    def get_max_vel_params(self, vmax: float, level_trim: float):
+        """
+        This function computes the elevator trim and maximum sink rate for maximum velocity 
+
+        :param vmax: maximum velocity (user input)
+        :return: differential elevator trim (to cruise trim), throttle setting for Vmax at level flight and maximum sink rate
+        """
+        print("Computing max velocity parameters...")
+
+        throttle_setting, _, elevator_trim = self.get_level_flight_params(vmax)
+        diff_trim = elevator_trim - level_trim
+
+        # compute max sink rate with motor off
+        def eom_zero_thrust(initial_values):
+            gamma, alpha = initial_values
+            return (- self.mass * self.gravity * np.sin(gamma) - self.drag(alpha, vmax),
+                    self.mass * self.gravity * np.cos(gamma) - self.lift(alpha, self.zero_moment_trim(alpha, 0.0, vmax), vmax))
+
+        gamma, alpha = fsolve(eom_zero_thrust, [- 0.2, 0.1])
+        max_sink_rate = vmax / (np.sqrt(1 + 1 / (np.tan(- gamma) ** 2)))
+        max_sink_trim = self.zero_moment_trim(alpha, 0.0, vmax)
+
+        print("Max velocity parameters computed successfully.")
+        print("Differential elevator trim: ", diff_trim,
+              "Max velocity level flight throttle setting: ", throttle_setting,
+              "Max sink rate at zero throttle: ", max_sink_rate,
+              "at user-specified max velocity: ", vmax,
+              "and angle of attack: ", alpha, '\n')
+
+        return float(max_sink_trim), float(max_sink_rate), float(diff_trim), float(throttle_setting)
+
+    def get_max_climb_params(self, airspeed):
+        print("Computing max climb rate parameters...")
+
+        def eom(initial_values):
+            aoa, gamma = initial_values
+            return (self.drag(aoa, airspeed) + self.mass * self.gravity * np.sin(gamma) - self.thrust(1.0) * np.cos(aoa),
+                    self.lift(aoa, self.zero_moment_trim(aoa, 1.0, airspeed), airspeed) - self.mass *
+                    self.gravity * np.cos(gamma) + self.thrust(1.0) * np.sin(aoa))
+
+        alpha, gamma = fsolve(eom, [0.0, 0.0])
+        elevator_trim = self.zero_moment_trim(alpha, 1.0, airspeed)
+
+        max_climb_rate = - airspeed / (np.sqrt(1 + 1 / (np.tan(- gamma) ** 2)))
+
+        print("Max climb rate parameters computed successfully.")
+        print("Angle of attack: ", alpha, "Elevator trim: ", elevator_trim,
+              "Speed for max climb rate: ", airspeed,
+              "Max climb rate: ", max_climb_rate, '\n')
+        return float(max_climb_rate), float(elevator_trim)
+
+    # auxilary function to compute the level flight parameters with missing angle of attack (but known velocity)
+    def get_level_flight_params(self, airspeed):
+        def throttle(alpha):
+            return self.drag(alpha, airspeed) / (self.aero_params['puller_ct'] * np.cos(alpha))
+
+        def eom_z(initial_value):
+            alpha = initial_value
+            return self.lift(alpha, self.zero_moment_trim(alpha, throttle(alpha), airspeed), airspeed) + \
+                self.thrust(throttle(alpha)) * np.sin(alpha) - \
+                self.gravity * self.mass
+
+        [alpha] = fsolve(eom_z, [0.2])
+        throttle_setting = throttle(alpha)
+        elevator_trim = self.zero_moment_trim(
+            alpha, throttle_setting, airspeed)
+        pitch_level_flight = alpha
+
+        return throttle_setting, pitch_level_flight, elevator_trim
+
+    # auxilary function to compute the flight speed from a given angle of attack and elevator trim at zero thrust
+    def get_flight_vel_zero_thrust(self, alpha):
+        """
+        This function computes the flight speed that corresponds to a certain 
+        elevator deflection, angle of attack and zero thrust, using the provided
+        aerodynamic parameters.
+
+        :param alpha: angle of attack
+
+        :return: flight speed, flight path angle
+        """
+        def gilde_eom(initial_values):
+            airspeed, gamma = initial_values
+            return (gamma + np.arctan2(self.cD(alpha), self.cL(alpha)),
+                    airspeed - np.sqrt((2 * self.mass * self.gravity) /
+                    (self.rho * self.area * (self.cL(alpha) * np.cos(gamma) - self.cD(alpha) * np.sin(gamma)))))
+
+        airspeed, flight_path_angle = fsolve(gilde_eom, [10.0, 0.2])
+
+        return airspeed, flight_path_angle

--- a/Tools/parametric_model/src/models/extractor_models/singularityfree_extractor_model.py
+++ b/Tools/parametric_model/src/models/extractor_models/singularityfree_extractor_model.py
@@ -90,14 +90,14 @@ class SingularityFreeExtractorModel():
         """
         return self.px4_params
 
-    def save_px4_params_to_yaml(self, output_file):
+    def save_px4_params_to_yaml(self, output_folder):
         """
         Save the extracted px4 parameters to a yaml file
 
-        :param output_file: path to the output file
+        :param output_folder: path to the output file
         """
         timestr = time.strftime("%Y-%m-%d-%H-%M-%S")
-        file_path = output_file + "_" + timestr + ".yaml"
+        file_path = output_folder + self.model_name + '_px4_params' + "_" + timestr + ".yaml"
 
         with open(file_path, 'w') as outfile:
             yaml.dump(self.px4_params, outfile, default_flow_style=False)

--- a/Tools/parametric_model/src/models/global_singularityfree_model.py
+++ b/Tools/parametric_model/src/models/global_singularityfree_model.py
@@ -1,0 +1,108 @@
+"""
+ *
+ * Copyright (c) 2023 Julius Schlapbach
+ *               2023 Autonomous Systems Lab ETH Zurich
+ * All rights reserved.
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name Data Driven Dynamics nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+"""
+
+__author__ = "Julius Schlapbach"
+__maintainer__ = "Julius Schlapbach"
+__license__ = "BSD 3"
+
+
+import numpy as np
+
+from .dynamics_model import DynamicsModel
+from .model_config import ModelConfig
+from .aerodynamic_models import PhiAerodynamicsModel
+
+
+class GlobalSingularityFreeModel(DynamicsModel):
+    def __init__(self, config_file, normalization=True, model_name="global_singularityfree_model"):
+        self.config = ModelConfig(config_file)
+        super(GlobalSingularityFreeModel, self).__init__(
+            config_dict=self.config.dynamics_model_config, normalization=normalization)
+        self.mass = self.config.model_config["mass"]
+        self.moment_of_inertia = np.diag([self.config.model_config["moment_of_inertia"]["Ixx"],
+                                         self.config.model_config["moment_of_inertia"]["Iyy"],
+                                         self.config.model_config["moment_of_inertia"]["Izz"]])
+
+        self.model_name = model_name
+
+        self.rotor_config_dict = self.config.model_config["actuators"]["rotors"]
+        self.aerodynamics_dict = self.config.model_config["aerodynamics"]
+
+    def prepare_force_regression_matrices(self):
+        accel_mat = self.data_df[[
+            "acc_b_x", "acc_b_y", "acc_b_z"]].to_numpy()
+        force_mat = accel_mat * self.mass
+        self.y_forces = (force_mat).flatten()
+        self.data_df[["measured_force_x", "measured_force_y",
+                     "measured_force_z"]] = force_mat
+
+        # Aerodynamics features
+        airspeed_mat = self.data_df[[
+            "V_air_body_x", "V_air_body_y", "V_air_body_z"]].to_numpy()
+        aoa_mat = self.data_df[["angle_of_attack"]].to_numpy()
+
+        aero_model = PhiAerodynamicsModel(self.aerodynamics_dict)
+        X_aero, coef_dict_aero, col_names_aero = aero_model.compute_aero_force_features(
+            airspeed_mat, aoa_mat[:, 0])
+        self.data_df[col_names_aero] = X_aero
+        self.coef_dict.update(coef_dict_aero)
+        self.y_dict.update({"lin": {"x": "measured_force_x",
+                           "y": "measured_force_y", "z": "measured_force_z"}})
+
+    def prepare_moment_regression_matrices(self):
+        # Angular acceleration
+        moment_mat = np.matmul(self.data_df[[
+            "ang_acc_b_x", "ang_acc_b_y", "ang_acc_b_z"]].to_numpy(), self.moment_of_inertia)
+        self.y_moments = moment_mat.flatten()
+        self.data_df[["measured_moment_x", "measured_moment_y",
+                     "measured_moment_z"]] = moment_mat
+
+        # Aerodynamics features
+        airspeed_mat = self.data_df[[
+            "V_air_body_x", "V_air_body_y", "V_air_body_z"]].to_numpy()
+        aoa_mat = self.data_df[["angle_of_attack"]].to_numpy()
+        sideslip_mat = self.data_df[["angle_of_sideslip"]].to_numpy()
+        angular_vel_mat = self.data_df[[
+            "ang_vel_x", "ang_vel_y", "ang_vel_z"]].to_numpy()
+        elevator_inputs = self.data_df["elevator"].to_numpy()
+
+        aero_model = PhiAerodynamicsModel(self.aerodynamics_dict)
+        X_aero, coef_dict_aero, col_names_aero = aero_model.compute_aero_moment_features(
+            airspeed_mat, aoa_mat[:, 0], sideslip_mat, elevator_inputs)
+
+        self.data_df[col_names_aero] = X_aero
+        self.coef_dict.update(coef_dict_aero)
+
+        self.y_dict.update({"rot": {"x": "measured_moment_x",
+                           "y": "measured_moment_y", "z": "measured_moment_z"}})


### PR DESCRIPTION
**Problem Description**
Until now, the global singularity-free model implemented for this pipeline was only usable with manual code modifications. 

**Proposed Solution**
- This pull request adds a separate config file `fixedwing_singularityfree_model.yaml`, which takes care of the correct setup for fixed wing flight logs.
- A corresponding extractor for PX4 parameters (as described in the README of the repository) was added for the global singularity-free model.

To apply it to fixedwing logs:
`python3 Tools/parametric_model/generate_parametric_model.py --config Tools/parametric_model/configs/fixedwing_singularityfree_model.yaml ULOG_FILE --normalization False --extraction True`