### PR TITLE
Fix interactive data selection when u2 is missing

### DIFF
--- a/Tools/parametric_model/generate_parametric_model.py
+++ b/Tools/parametric_model/generate_parametric_model.py
@@ -85,10 +85,13 @@ def start_model_estimation(config, log_path, data_selection="none", plot=False, 
     # Interactive data selection
     if data_selection=="interactive":
         from visual_dataframe_selector.data_selector import select_visual_data
+        # Parse actuator topics, and remove the timestamp from it
+        actuator_topics = data_handler.config_dict["data"]["required_ulog_topics"]["actuator_outputs"]["dataframe_name"]
+        actuator_topics.remove('timestamp')
         visual_dataframe_selector_config_dict = {
         "x_axis_col": "timestamp",
         "sub_plt1_data": ["q0", "q1", "q2", "q3"],
-        "sub_plt2_data": ["u0", "u1", "u2", "u3"],
+        "sub_plt2_data": actuator_topics,
         "sub_plt3_data": []
         }
 


### PR DESCRIPTION
**Problem Description**
For interactive data selection, required topics are hard coded as `u1`, `u2`, `u3`, `u4`, and therefore makes the whole data selection fail if the topics are missing.

```
-------------------------------------------------------------------------------
Initialized dataframe with the following columns: 
['timestamp', 'u0', 'u1', 'u3', 'u4', 'u6', 'vx', 'vy', 'vz', 'q0', 'q1', 'q2', 'q3', 'ang_vel_x', 'ang_vel_y', 'ang_vel_z', 'ang_acc_b_x', 'ang_acc_b_y', 'ang_acc_b_z', 'acc_b_x', 'acc_b_y', 'acc_b_z', 'aux1', 'throttle', 'aileron', 'elevator', 'rudder', 'landed']
Data contains  37240 timestamps.
Computing force features for rotor
Computing moment features for rotor
Feature Computation |############################### | 37239/37240
Starting computation of aero moment features...
Feature Computation |############################### | 37239/37240
Cramer-Rao Bounds for force parameters:
puller_ct        0.07680642694482716
cl0      0.0012209864133548663
clalpha          0.012535964817765585
cldelta          0.006355243273722874
cd0      0.0010122110113291545
cdalpha          0.015118351468713459
cdalphasq        0.10865791831861082
Cramer-Rao Bounds for moment parameters:
puller_cmt       0.03374473061061396
cm0      0.002834858821845869
cmalpha          0.028497883320081425
cmdelta          0.01747374099395526
cmq      1.2087047286233417
['timestamp', 'u0', 'u1', 'u3', 'u4', 'u6']
inotify_add_watch(/home/jaeyoung/.config/ibus/bus/f7f12eb0d0ee44a092b8313f7b037850-unix-1) failed: (No space left on device)
Traceback (most recent call last):
  File "/home/jaeyoung/.local/lib/python3.6/site-packages/pandas/core/indexes/base.py", line 2898, in get_loc
    return self._engine.get_loc(casted_key)
  File "pandas/_libs/index.pyx", line 70, in pandas._libs.index.IndexEngine.get_loc
  File "pandas/_libs/index.pyx", line 101, in pandas._libs.index.IndexEngine.get_loc
  File "pandas/_libs/hashtable_class_helper.pxi", line 1675, in pandas._libs.hashtable.PyObjectHashTable.get_item
  File "pandas/_libs/hashtable_class_helper.pxi", line 1683, in pandas._libs.hashtable.PyObjectHashTable.get_item
KeyError: 'u2'

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "Tools/parametric_model/generate_parametric_model.py", line 152, in <module>
    start_model_estimation(**vars(arg_list))
  File "Tools/parametric_model/generate_parametric_model.py", line 102, in start_model_estimation
    model.load_dataframes(select_visual_data(model.data_df,visual_dataframe_selector_config_dict))
  File "/home/jaeyoung/dev/data-driven-dynamics/Tools/parametric_model/visual_dataframe_selector/data_selector.py", line 19, in select_visual_data
    w = MainWindow(data_df, plot_config_dict)
  File "/home/jaeyoung/dev/data-driven-dynamics/Tools/parametric_model/visual_dataframe_selector/src/main_window.py", line 47, in __init__
    self.setup_plots()
  File "/home/jaeyoung/dev/data-driven-dynamics/Tools/parametric_model/visual_dataframe_selector/src/main_window.py", line 111, in setup_plots
    self.data_df[self.x_axis_col], self.data_df[topic], label=topic)
  File "/home/jaeyoung/.local/lib/python3.6/site-packages/pandas/core/frame.py", line 2906, in __getitem__
    indexer = self.columns.get_loc(key)
  File "/home/jaeyoung/.local/lib/python3.6/site-packages/pandas/core/indexes/base.py", line 2900, in get_loc
    raise KeyError(key) from err
KeyError: 'u2'
```

**Proposed Solution**
This PR fixes this by parsing the required actuator topic from the config directly.