### PR TITLE
 enhance: change flight time extraction to be able to detect multiple flight segments in single log file

### DIFF
--- a/Tools/parametric_model/src/tools/data_handler.py
+++ b/Tools/parametric_model/src/tools/data_handler.py
@@ -124,7 +124,13 @@ class DataHandler(object):
             # compute flight time based on the landed topic
             landed_df = pandas_from_topic(ulog, ["vehicle_land_detected"])
             fts = compute_flight_time(landed_df)
-            self.data_df = self.compute_resampled_dataframe(ulog, fts)
+
+            if len(fts) == 1:
+                self.data_df = self.compute_resampled_dataframe(ulog, fts[0])
+            else:
+                for ft in fts:
+                    self.data_df.append(self.compute_resampled_dataframe(ulog, ft))
+
             return True
 
         else:

--- a/Tools/parametric_model/src/tools/data_handler.py
+++ b/Tools/parametric_model/src/tools/data_handler.py
@@ -129,7 +129,11 @@ class DataHandler(object):
                 self.data_df = self.compute_resampled_dataframe(ulog, fts[0])
             else:
                 for ft in fts:
-                    self.data_df.append(self.compute_resampled_dataframe(ulog, ft))
+                    # check if the dataframe already exists and if so, append to it
+                    if getattr(self, "data_df", None) is None:
+                        self.data_df = self.compute_resampled_dataframe(ulog, ft)
+                    else:
+                        self.data_df.append(self.compute_resampled_dataframe(ulog, ft))
 
             return True
 


### PR DESCRIPTION
**Problem Description:**
This PR addresses the problem described in issue #223. The flight time extraction step was limited to cases where the log only contains a single flight. This might cause problems, if the landed topic deviates from the `landed` state for example due to bumps on landing.

**Proposed Solution:**
The implementation of the flight time computation has been modified to work with an arbitrary number of flights in a single log. All flight segments will simply be concatenated.