### PR TITLE
Visualize data points in the liftdrag plot

### DIFF
--- a/Tools/parametric_model/src/models/dynamics_model.py
+++ b/Tools/parametric_model/src/models/dynamics_model.py
@@ -823,7 +823,9 @@ class DynamicsModel:
         if hasattr(self, "aerodynamics_dict"):
             coef_list = self.optimizer.get_optimization_parameters()
             coef_dict = dict(zip(self.coef_name_list, coef_list))
-            aerodynamics_plots.plot_liftdrag_curve(coef_dict, self.aerodynamics_dict)
+            aerodynamics_plots.plot_liftdrag_curve(
+                self.data_df, coef_dict, self.aerodynamics_dict
+            )
         plt.tight_layout()
         plt.show()
         return


### PR DESCRIPTION
**Problem Description**
While the lift drag curve visualization is quite useful to see what the identified aerodynamics model looks like, a lot of the curve is actually extrapolating from measured data.

This PR visualizes the data points of angle of attack on the curve to visualize which data is being used for the extrapolation.


**Note**
Note that the measurements are perfectly "on the curve" since only the measured angle of attack is being used and the identified model is used to compute `c_l` and `c_d`. This should be replaced by "measured" `c_l` and `c_d` in a future PR

**Testing**
- log: https://review.px4.io/plot_app?log=a967d7a5-10fa-41ca-b43a-1abaebce044a (from https://github.com/ethz-asl/data-driven-dynamics/issues/224)
```
make estimate-model model=fixedwing_model data_selection=setpoint log=resources/a967d7a5-10fa-41ca-b43a-1abaebce044a.ulg  
```
- LinearWingModel
![Figure_6](https://github.com/ethz-asl/data-driven-dynamics/assets/5248102/740cb505-3af4-49ed-a31f-6489a17818e2)

- PhiAerodynamicsModel
![Figure_6](https://github.com/ethz-asl/data-driven-dynamics/assets/5248102/1015717f-7c61-42bf-b2a5-e474a2113e99)

