### PR TITLE
Remove vpselector submodule and add as pypi dependency

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -16,7 +16,6 @@ jobs:
       matrix:
         container:
           - "px4io/px4-dev-simulation-focal:2021-05-31" # Gazebo 11
-          - "px4io/px4-dev-simulation-bionic:2021-05-31" # Gazebo 9
     container: ${{ matrix.container }}
     steps:
       - uses: actions/checkout@v1

--- a/.github/workflows/sysid_test.yml
+++ b/.github/workflows/sysid_test.yml
@@ -16,7 +16,6 @@ jobs:
       matrix:
         container:
           - "px4io/px4-dev-simulation-focal:2020-11-18" # Gazebo 11
-          - "px4io/px4-dev-simulation-bionic:2020-11-18" # Gazebo 9
     container: ${{ matrix.container }}
     steps:
       - uses: actions/checkout@v1

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "Tools/parametric_model/libs/vpselector"]
-	path = Tools/parametric_model/libs/vpselector
-	url = https://github.com/manumerous/vpselector.git

--- a/Tools/parametric_model/requirements.txt
+++ b/Tools/parametric_model/requirements.txt
@@ -10,3 +10,4 @@ pytest==6.2.3
 progress==1.5
 cvxpy>=1.1.0
 seaborn>=0.10.0
+vpselector>=1.0.1


### PR DESCRIPTION
The Visual Pandas selector is now available as an official python package on PyPi. Therefore i suggest removing the submodule and just installing it regularly like all the other python dependencies.  