### PR TITLE
fix: ensure that model prediction with makefile command works as expected

### DIFF
--- a/Tools/parametric_model/predict_model.py
+++ b/Tools/parametric_model/predict_model.py
@@ -5,7 +5,7 @@ __license__ = "BSD 3"
 import os
 import sys
 import inspect
-from src.models import MultiRotorModel, SimpleFixedWingModel, QuadPlaneModel
+from src.models import MultiRotorModel, FixedWingModel
 from src.models.model_config import ModelConfig
 import src.models as models
 from src.tools import DataHandler


### PR DESCRIPTION
**Problem Description:**
This pull request addresses the problems described in #233. The prediction command does not work at the moment.

**Proposed Solution:**
The prediction script and/or the correspondingly used functions therein have been adapted to use the interfaces, which the estimation tasks also use. Additionally, only the model results and no fisher information is logged to resolve corresponding errors.

